### PR TITLE
feat(v0.1.0): MVP Pillars & Direction

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -6,7 +6,7 @@
   },
   "metadata": {
     "description": "Direction-first audit & kickoff lens for Claude Code projects. Born from Evo-Tactics design philosophy.",
-    "version": "0.0.1"
+    "version": "0.1.0"
   },
   "plugins": [
     {
@@ -15,7 +15,7 @@
         "source": "local",
         "path": "plugins/compass"
       },
-      "version": "0.0.1",
+      "version": "0.1.0",
       "description": "Direction Index + Pillars + Drift detection for any Claude Code project. Composes with existing audit plugins instead of duplicating them.",
       "category": "productivity",
       "keywords": [

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -29,7 +29,9 @@ chiedi all'utente.
 
 ## Stack & comandi
 
-- **Linguaggio**: Python 3.8+ (stdlib only — niente pip install)
+- **Linguaggio**: Python 3.11+ (stdlib only — niente pip install).
+  Il bump a 3.11 è richiesto per `tomllib` (parser TOML stdlib, usato per
+  `.compass.toml`). Vedi `docs/config.md` §7.
 - **Formato**: Claude Code plugin spec (vedi `.claude-plugin/`)
 - **Test**: `pytest` se introdotto, `python3 -m unittest` come fallback
 - **Lint**: nessun linter forzato. Se serve: `ruff check` (opzionale)
@@ -46,7 +48,7 @@ python3 -m json.tool plugins/compass/.claude-plugin/plugin.json
 
 ## Architettura — i 3 primitivi
 
-1. **Pillars** — file `.compass.yaml` nella root del progetto utente, dichiara
+1. **Pillars** — file `.compass.toml` nella root del progetto utente, dichiara
    3–5 cose che contano. Schema in `docs/config.md` (da scrivere v0.1.0).
 2. **Direction Index** — numero 0–100. Pesato su % commit Core, copertura
    pilastri, issue chiuse.
@@ -105,7 +107,7 @@ Scope tipici: `init`, `check`, `boot`, `drift`, `evolve`, `marketplace`,
 
 Chiedi sempre prima di:
 - Aggiungere una dipendenza esterna
-- Modificare lo schema di `.compass.yaml`
+- Modificare lo schema di `.compass.toml`
 - Creare un nuovo command top-level
 - Modificare README/VISION/ROADMAP (sono fonti di verità)
 - Pushare su `main` (preferisci branch + chiedi review)

--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ milestone.
 /plugin install compass@compass-marketplace
 
 # Primo uso
-/compass init
+/compass:init
 ```
 
 Nella v0.0.1 corrente l'installazione funziona come test ma i comandi non
@@ -75,11 +75,11 @@ sono ancora implementati — parte dalla v0.1.0.
 ## Anteprima dei comandi (target)
 
 ```
-/compass init       → interattivo, definisce i pilastri del progetto
-/compass check      → Direction Index + stato pilastri (briefing <1 min)
-/compass boot       → kickoff direzionale: briefing + deleghe ai plugin giusti
-/compass drift      → cerca segnali di deriva nei commit/issue recenti
-/compass evolve     → legge i transcript, propone modifiche a .compass.yaml
+/compass:init       → interattivo, definisce i pilastri del progetto
+/compass:check      → Direction Index + stato pilastri (briefing <1 min)
+/compass:boot       → kickoff direzionale: briefing + deleghe ai plugin giusti
+/compass:drift      → cerca segnali di deriva nei commit/issue recenti
+/compass:evolve     → legge i transcript, propone modifiche a .compass.toml
 ```
 
 Plus un `SessionStart` hook opzionale che inietta un mini-brief all'apertura.

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -31,16 +31,17 @@ Il principio ogni volta: **se non serve ancora, non costruirlo.**
 
 **Scope:** due comandi che dimostrano la lente.
 
-- [ ] `/compass:init` — interattivo, aiuta l'utente a definire 3–5 pilastri
+- [x] `/compass:init` — interattivo, aiuta l'utente a definire 3–5 pilastri
       nel progetto corrente. Scrive `.compass.toml`.
-- [ ] `/compass:check` — calcola il Direction Index basandosi su:
+- [x] `/compass:check` — calcola il Direction Index basandosi su:
     - ultimi N commit (classificati per categoria)
     - stato dei pilastri (ha file recenti?)
     - issue chiuse recenti (se `gh` è disponibile)
-- [ ] Schema di `.compass.toml` documentato in `docs/config.md`
+- [x] Schema di `.compass.toml` documentato in `docs/config.md`
 - [ ] Test manuale su 3 progetti diversi: Evo-Tactics (gaming), un SaaS di
-      esempio, un repo di docs
-- [ ] Skill `compass-lens` che Claude auto-invoca quando l'utente chiede
+      esempio, un repo di docs *(self-test su `compass-marketplace`
+      eseguito; cross-project rimane pendente)*
+- [x] Skill `compass-lens` che Claude auto-invoca quando l'utente chiede
       "dove sto andando", "sono sulla strada giusta", "check del progetto"
 
 **Criterio di done:** su un progetto con pilastri dichiarati, `/compass:check`

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -31,19 +31,19 @@ Il principio ogni volta: **se non serve ancora, non costruirlo.**
 
 **Scope:** due comandi che dimostrano la lente.
 
-- [ ] `/compass init` — interattivo, aiuta l'utente a definire 3–5 pilastri
-      nel progetto corrente. Scrive `.compass.yaml`.
-- [ ] `/compass check` — calcola il Direction Index basandosi su:
+- [ ] `/compass:init` — interattivo, aiuta l'utente a definire 3–5 pilastri
+      nel progetto corrente. Scrive `.compass.toml`.
+- [ ] `/compass:check` — calcola il Direction Index basandosi su:
     - ultimi N commit (classificati per categoria)
     - stato dei pilastri (ha file recenti?)
     - issue chiuse recenti (se `gh` è disponibile)
-- [ ] Schema di `.compass.yaml` documentato in `docs/config.md`
+- [ ] Schema di `.compass.toml` documentato in `docs/config.md`
 - [ ] Test manuale su 3 progetti diversi: Evo-Tactics (gaming), un SaaS di
       esempio, un repo di docs
 - [ ] Skill `compass-lens` che Claude auto-invoca quando l'utente chiede
       "dove sto andando", "sono sulla strada giusta", "check del progetto"
 
-**Criterio di done:** su un progetto con pilastri dichiarati, `/compass check`
+**Criterio di done:** su un progetto con pilastri dichiarati, `/compass:check`
 produce un briefing sotto i 60 secondi con numeri reali.
 
 **Stima:** un weekend.
@@ -54,12 +54,12 @@ produce un briefing sotto i 60 secondi con numeri reali.
 
 **Scope:** il comando di apertura sessione.
 
-- [ ] `/compass boot` — sostituisce il vecchio `/kickoff` con una versione
+- [ ] `/compass:boot` — sostituisce il vecchio `/kickoff` con una versione
       direction-aware
 - [ ] SessionStart hook opzionale, che inietta un mini-brief (3–5 righe)
       all'apertura di ogni sessione
 - [ ] Integrazione **opzionale** con `claude-md-management`: se installato
-      e se `.compass.yaml` lo permette, `boot` può chiederne l'invocazione
+      e se `.compass.toml` lo permette, `boot` può chiederne l'invocazione
 - [ ] Escape hatch `skip boot` rispettato
 
 **Criterio di done:** aprire una sessione dentro un progetto con Compass
@@ -74,7 +74,7 @@ può sempre disattivare o skippare.
 
 **Scope:** identificare e riportare deriva in modo concreto.
 
-- [ ] `/compass drift` — report dedicato con i segnali rilevati
+- [ ] `/compass:drift` — report dedicato con i segnali rilevati
 - [ ] Classificatore commit migliorato: euristica su path + keyword + AI
       classification opzionale (costo controllato)
 - [ ] Soglia configurabile: sotto quale Direction Index emettiamo warning
@@ -82,7 +82,7 @@ può sempre disattivare o skippare.
       possibile, mai un macro-task
 
 **Criterio di done:** su un progetto con 2+ settimane di deriva (molti
-commit infra, zero commit core), `/compass drift` produce un warning
+commit infra, zero commit core), `/compass:drift` produce un warning
 chiaro + il next-action più piccolo.
 
 **Stima:** mezza settimana.
@@ -96,7 +96,7 @@ chiaro + il next-action più piccolo.
 - [ ] Lettura di `~/.claude/projects/**/*.jsonl` filtrando per progetto corrente
 - [ ] Statistiche: quante volte ogni task del boot è stato eseguito, quante
       volte ha trovato qualcosa, quante volte è stato skippato
-- [ ] `/compass evolve` — presenta un **diff proposto** al `.compass.yaml`
+- [ ] `/compass:evolve` — presenta un **diff proposto** al `.compass.toml`
       basato sui pattern osservati
 - [ ] L'utente approva in modalità chirurgica (accept, reject, modify)
 - [ ] Mai applicare modifiche senza consenso esplicito
@@ -137,12 +137,12 @@ Compass li usa come subagent invece di replicare le loro funzioni.
     - [ ] Web SaaS (default: core funnel/perf/onboarding/reliability)
     - [ ] Research repo (default: experiments/data/writeup/reproducibility)
     - [ ] Library/SDK (default: API stability/examples/perf/compat)
-- [ ] `/compass init` può proporre il template giusto dopo aver ispezionato
+- [ ] `/compass:init` può proporre il template giusto dopo aver ispezionato
       il repo
 - [ ] Traduttore Evo-Tactics → progetto (tipo in `VISION.md` §5) esposto
-      come `/compass translate`
+      come `/compass:translate`
 
-**Criterio di done:** `/compass init` su un repo vanilla di qualsiasi tipo
+**Criterio di done:** `/compass:init` su un repo vanilla di qualsiasi tipo
 produce una config iniziale ragionevole in <2 minuti.
 
 **Stima:** 1 settimana.

--- a/VISION.md
+++ b/VISION.md
@@ -46,7 +46,7 @@ stabilità, perf, esempi.
 Il 90% dei progetti non le scrive mai. Le ha in testa, cambiano nel tempo,
 e quando il team cresce si perdono.
 
-Compass costringe a dichiararli in `.compass.yaml`. Questa è la prima
+Compass costringe a dichiararli in `.compass.toml`. Questa è la prima
 scoperta utile del tool: molti progetti si accorgono che non sanno
 **esattamente** cosa sono i loro pilastri finché non devono scriverli.
 
@@ -91,8 +91,8 @@ in maniera concreta per non essere fluffy:
 │  2. Hook SessionStart inietta un mini-brief         │
 │  3. Se il kickoff trova poco, logga "soft session"  │
 │  4. Se trova tanto, logga "hot session"             │
-│  5. Dopo N sessioni, /compass evolve propone        │
-│     modifiche a .compass.yaml:                      │
+│  5. Dopo N sessioni, /compass:evolve propone        │
+│     modifiche a .compass.toml:                      │
 │       → disabilita task che non trovano mai nulla   │
 │       → promuove task che trovano sempre issue      │
 │       → raffina pesi dei pilastri                   │
@@ -142,7 +142,7 @@ Traduzione universale in Compass:
 | **Tooling** | Script interni, generator, linter config | 0 |
 | **Other** | Tutto il resto | 0 |
 
-I pesi sono modificabili in `.compass.yaml`. Il default penalizza lievemente
+I pesi sono modificabili in `.compass.toml`. Il default penalizza lievemente
 l'infra dominante — è una scelta di game-design culture trasposta: se il
 tuo tempo scarseggia, l'infrastruttura è sempre tentazione.
 

--- a/docs/config.md
+++ b/docs/config.md
@@ -1,0 +1,351 @@
+# `.compass.toml` — schema di configurazione
+
+> Documento normativo per la v0.1.0. Schema minimale. Ogni campo ha un
+> default ragionevole: un `.compass.toml` valido può essere lungo 10 righe.
+>
+> **Formato**: TOML (parsato con `tomllib`, stdlib Python ≥ 3.11).
+> **Decisione** in §7.
+
+---
+
+## 1. Posizione e formato
+
+- **Path**: `.compass.toml` nella root del progetto utente (stesso livello
+  di `.git/`).
+- **Formato**: [TOML 1.0.0](https://toml.io/en/v1.0.0).
+- **Parser**: `tomllib` (Python stdlib, ≥ 3.11). Zero dipendenze.
+- **Writer (in `/compass:init`)**: emissione via template string + check
+  di round-trip con `tomllib.loads` prima di scrivere.
+- **Encoding**: UTF-8, LF.
+- **Versione schema**: campo `version` obbligatorio. v0.1.0 → `version = 1`.
+
+## 2. Schema completo (con default)
+
+```toml
+# Versione dello schema. Obbligatorio. v0.1.0 scrive e legge solo
+# `version = 1`.
+version = 1
+
+# Metadati del progetto. Il `type` influenza solo i template di init.
+[project]
+name = "compass-marketplace"    # default: nome della directory root
+type = "library"                # one of: game-dev | web-saas | research
+                                #         library | docs | other
+                                # default: "other"
+
+# I pilastri. 3-5 raccomandati. Minimo 1, massimo 10.
+# Ogni pilastro è una `[[pillars]]` table entry (array-of-tables TOML).
+# L'id deve essere kebab-case unico.
+[[pillars]]
+id = "direction-lens"
+name = "Direction Index & pillars core"
+description = "Il cuore del plugin: lente, non sistema."
+paths = [                        # path glob (fnmatch-style, POSIX)
+  "plugins/compass/commands/**",
+  "plugins/compass/skills/**",
+  "plugins/compass/scripts/**",
+]
+weight = 1.0                     # default 1.0. Relativo agli altri pilastri.
+
+[[pillars]]
+id = "docs-governance"
+name = "Governance dei documenti"
+description = "VISION/ROADMAP/CLAUDE come fonti di verità."
+paths = ["VISION.md", "ROADMAP.md", "CLAUDE.md", "docs/**"]
+weight = 0.7
+
+# Categorie di classificazione. I path delle categorie sono
+# **complementari** ai pilastri: un file che matcha un pilastro è sempre
+# "core", anche se matcherebbe anche "docs". Regola di matching:
+# first-match wins nell'ordine [pillars → core → tests → docs → infra
+# → tooling → other].
+
+[categories.core]
+# Se vuoto (default), derivato implicitamente dall'unione dei
+# `pillars[].paths`. Può essere esteso qui per path "core ma non
+# associati a un pilastro specifico" (raro, sconsigliato).
+paths = []
+weight = 1.0
+message_patterns = ["^feat", "^feature"]   # opzionale. Default [].
+
+[categories.tests]
+paths = ["tests/**", "**/*_test.py", "**/*.test.*", "**/*.spec.*"]
+weight = 0.5
+message_patterns = ["^test"]
+
+[categories.docs]
+paths = ["docs/**", "**/*.md", "README*", "LICENSE*"]
+weight = 0.3
+message_patterns = ["^docs?"]
+
+[categories.infra]
+paths = [".github/**", "Dockerfile*", "docker-compose*", "ci/**",
+         ".gitlab-ci.yml", "Makefile"]
+weight = -0.1                    # leggera penalità se prevalente
+message_patterns = ["^ci", "^build"]
+
+[categories.tooling]
+paths = ["scripts/**", "tools/**", ".pre-commit-config.yaml"]
+weight = 0.0
+message_patterns = ["^chore"]
+
+# "other" è sempre l'ultimo, non configurabile, peso 0.
+
+# Direction Index (0-100). Formula (vedi VISION.md §1, tradotta
+# in universale):
+#   ID = core_share      * 40
+#      + pillar_coverage * 40
+#      + issue_factor    * 20
+[direction]
+window = 30                      # commit da analizzare. default 30.
+                                 # range: 5..500.
+
+[direction.formula]
+core_share = 0.4
+pillar_coverage = 0.4
+issue_factor = 0.2
+
+[direction.thresholds]
+healthy = 60                     # >= 60: "rotta coerente"
+warning = 40                     # < 40: "deriva evidente"
+                                 # 40-59: "attenzione"
+
+# Integrazione con GitHub issues (opzionale, v0.1.0 read-only).
+# Se `gh` CLI non disponibile o `enabled = false`, issue_factor = 0.5
+# (neutro).
+[issues]
+enabled = false
+closed_window_days = 30
+
+# Path esclusi dall'analisi (rumore tipico).
+ignore = [
+  ".git/**",
+  "node_modules/**",
+  "**/__pycache__/**",
+  "*.lock",
+  "dist/**",
+  "build/**",
+]
+
+# Forward-compat. In v0.1.0 questi campi sono letti ma ignorati.
+[evolve]
+enabled = false                  # v0.4.0
+
+delegate_to = []                 # v0.5.0
+```
+
+## 3. Minimal valid file
+
+```toml
+version = 1
+
+[[pillars]]
+id = "core"
+name = "Core product"
+paths = ["src/**"]
+```
+
+Tutto il resto usa i default. Direction Index calcolabile.
+
+## 4. Regole di validazione (applicate da `init` e `check`)
+
+| Campo | Vincolo |
+|---|---|
+| `version` | deve essere `1` (int) |
+| `pillars` | 1 ≤ len ≤ 10 |
+| `pillars[].id` | kebab-case, unico, regex `^[a-z][a-z0-9-]{1,40}$` |
+| `pillars[].paths` | len ≥ 1, ogni path non vuoto, string |
+| `pillars[].weight` | 0.0 ≤ w ≤ 10.0, default 1.0 |
+| `direction.window` | 5 ≤ w ≤ 500 |
+| `direction.formula.*` | somma dei 3 pesi = 1.0 ± 0.001 |
+| `direction.thresholds.healthy` | `> warning`, entrambi in [0, 100] |
+| `project.type` | uno di: game-dev, web-saas, research, library, docs, other |
+| `categories.*.weight` | -1.0 ≤ w ≤ 2.0 |
+| `categories.*.message_patterns` | list di stringhe regex valide (opzionale) |
+
+Violazioni → `check` stampa errore specifico con riga TOML e esce non-zero.
+`init` rigetta input invalidi e richiede correzione.
+
+## 5. Path matching
+
+- **Stile glob**: fnmatch POSIX esteso con `**` (qualsiasi numero di
+  segmenti). Case-sensitive. Relativo alla root del progetto. Sintassi
+  deliberatamente allineata a `CODEOWNERS` / `.gitignore` per leva
+  cognitiva: chi sa scrivere quelli sa scrivere pillar.paths.
+- **Ordine di match**: per ogni file del commit, si tenta in ordine
+  (**first-match wins**, non last-match come CODEOWNERS — mentalmente più
+  semplice):
+  1. Tutti i `[[pillars]].paths` (in ordine di dichiarazione). Primo
+     match → file è "core" + associato a quel pilastro (per pillar_coverage).
+  2. `categories.core.paths` espliciti.
+  3. `categories.tests.paths`.
+  4. `categories.docs.paths`.
+  5. `categories.infra.paths`.
+  6. `categories.tooling.paths`.
+  7. Fallback: `other`.
+- **Ignore**: i path che matchano `ignore` sono scartati prima del match.
+
+### 5.1 Segnale secondario: commit message prefix (opzionale)
+
+Classificazione ibrida path + messaggio (stile semantic-release). Per ogni
+commit, se il prefisso del primo rigo messaggio matcha un pattern
+`message_patterns` di una categoria, si applica una regola di conferma.
+
+Regola:
+- Se la category dominante del commit (per score pesato dei file) **concorda**
+  con la category che matcha il prefisso del messaggio → peso × 1.0
+  ("verified").
+- Se **discorda** (es. `feat:` ma file tutti in `.github/`) → peso × 0.5
+  ("ambiguous commit": squalifica parziale).
+- Se nessun pattern matcha → neutro, peso × 1.0.
+
+Default: tutti `message_patterns` vuoti → segnale disabilitato,
+classificazione pure-path. Utenti che seguono Conventional Commits lo
+abilitano esplicitamente.
+
+## 6. Unità di calcolo
+
+Un commit con N file modificati contribuisce con **N voti pesati**:
+
+```
+score(file)  = category.weight  (della categoria a cui appartiene)
+core_share   = sum(score di file core) / sum(|score| di tutti i file)
+```
+
+Il motivo per cui usiamo **file** e non commit: un commit che tocca 1 file
+core e 50 file infra non è "50% core". È "per lo più infra che passa
+vicino al core". La granularità file è più onesta.
+
+`pillar_coverage` invece conta pilastri unici toccati almeno una volta nel
+window, indipendentemente dal peso.
+
+`issue_factor = closed_issues / max(1, total_issues)` nel window temporale,
+solo se `issues.enabled = true` e `gh` CLI disponibile. Altrimenti 0.5.
+
+## 7. Decisione tecnica: TOML, non YAML
+
+TOML adottato per v0.1.0. Ragioni:
+
+| Vincolo | YAML | JSON | **TOML** |
+|---|---|---|---|
+| Python stdlib parser | ❌ (nessuno) | ✅ `json` | ✅ `tomllib` (3.11+) |
+| Commenti | ✅ | ❌ | ✅ |
+| Writability umana | ✅ | ❌ (quote-all) | ✅ |
+| Complessità parser nostro | ~200 LOC ad-hoc | 0 | 0 |
+| Rischio bug parser | alto | 0 | 0 |
+
+**Costo di TOML**:
+- Sintassi `[[pillars]]` array-of-tables nuova per chi non ha mai usato
+  `pyproject.toml` / `Cargo.toml`. Imparabile in 30 secondi.
+- Richiede Python **3.11+** (ottobre 2022). Bump dalla soglia `3.8+`
+  dichiarata inizialmente in `CLAUDE.md`.
+
+**Benefici**:
+- Zero LOC di parser code nel plugin.
+- Zero surface per bug subtili di parsing (errori di indentazione,
+  ambiguità scalari).
+- Tipizzazione forte (int vs float vs bool vs string non ambigua).
+- Spec formale (toml.io) — nessun "sottoinsieme Compass" da documentare.
+
+Scartato: parser YAML subset ad-hoc (rischioso), JSON (no commenti,
+inumano), JSONC (riscrivere parser comunque per strippare commenti).
+
+Il nome `.compass.toml` sostituisce `.compass.yaml` dei documenti
+precedenti (VISION/ROADMAP). Aggiornamento atomico di quei documenti
+richiesto nella stessa PR di v0.1.0.
+
+## 8. Esempio realistico (compass-marketplace)
+
+```toml
+version = 1
+
+[project]
+name = "compass-marketplace"
+type = "library"
+
+[[pillars]]
+id = "direction-lens"
+name = "Direction Index core"
+description = "Commands init/check + skill di lente."
+paths = [
+  "plugins/compass/commands/**",
+  "plugins/compass/skills/**",
+  "plugins/compass/scripts/**",
+  "plugins/compass/lib/**",
+]
+weight = 1.0
+
+[[pillars]]
+id = "docs-truth"
+name = "Documenti canonici"
+description = "VISION/ROADMAP/CLAUDE come fonti di verità."
+paths = ["VISION.md", "ROADMAP.md", "CLAUDE.md", "docs/**"]
+weight = 0.7
+
+[[pillars]]
+id = "manifest-validity"
+name = "Manifest plugin & marketplace"
+description = "I due plugin.json e marketplace.json valid."
+paths = [
+  ".claude-plugin/marketplace.json",
+  "plugins/*/plugin.json",
+  "plugins/*/.claude-plugin/plugin.json",
+]
+weight = 0.5
+
+[direction]
+window = 30
+
+[issues]
+enabled = true
+closed_window_days = 30
+```
+
+## 9. Output contract di `/compass:check`
+
+Il briefing deve essere **decomposto**, non monolitico (lezione da
+claude-doctor-skill: un singolo numero senza breakdown non è azionabile).
+
+Struttura minima del report markdown:
+
+```
+# Compass — Direction check
+
+**Direction Index: 67 / 100** ·  window: 30 commits · generated: 2026-04-25
+
+## Breakdown
+| Componente       | Peso | Valore | Contributo |
+|------------------|-----:|-------:|-----------:|
+| Core share       | 0.40 |    58% |       23.2 |
+| Pillar coverage  | 0.40 |   3/4  |       30.0 |
+| Issue factor     | 0.20 |   0.69 |       13.8 |
+
+## Pilastri nel window
+- [x] direction-lens (12 commit, 45% peso)
+- [x] docs-truth (8 commit, 25% peso)
+- [x] manifest-validity (2 commit, 8% peso)
+- [ ] **untouched-pillar** ← 0 commit in 30 commit
+
+## Drift signals (ranked)
+1. `docs-truth` ha avuto 0 commit negli ultimi 10 giorni (peso alto).
+2. 40% dei commit in window sono `infra` (normalmente <10%).
+
+## Next smallest step
+Apri un commit su `untouched-pillar`. Il path più promettente:
+`plugins/compass/skills/compass-lens/` (vuoto attualmente).
+```
+
+Vincoli obbligatori sull'output:
+- **Sempre** mostra breakdown. DI senza breakdown è vietato.
+- **Ranked drift signals**: top 3, ordinati per impatto su DI.
+- **Next smallest step**: 1 azione concreta, path specifico se possibile.
+- Lunghezza totale ≤ 40 righe markdown. Lente, non report.
+
+## 10. Cosa lo schema NON fa
+
+- Non dichiara autori, branch protetti, dipendenze. (Non è Compass.)
+- Non definisce workflow CI. (Non è Compass.)
+- Non schedula cron / notifiche. (Non è Compass.)
+- Non descrive un DAG di task. (Non è Compass.)
+
+Se ti viene voglia di aggiungere qualcosa qui, rileggi `VISION.md §4`.

--- a/plugins/compass/.claude-plugin/plugin.json
+++ b/plugins/compass/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://json.schemastore.org/claude-code-plugin.json",
   "name": "compass",
-  "version": "0.0.1",
+  "version": "0.1.0",
   "description": "Direction-first audit lens for Claude Code projects. Measures how well recent work serves the project's pillars, surfaces drift, and runs adaptive kickoff protocols. Composes with claude-md-management, doctor-skill, and audit-project rather than duplicating them.",
   "author": {
     "name": "MasterDD-L34D"

--- a/plugins/compass/README.md
+++ b/plugins/compass/README.md
@@ -21,15 +21,16 @@ See [ROADMAP.md](../../ROADMAP.md) for milestones.
 
 ## Components (target, not yet shipped)
 
-- `commands/` — slash commands (`/compass init|check|boot|drift|evolve`)
+- `skills/` — slash commands implemented as `SKILL.md` (namespaced
+  `/compass:init|check|boot|drift|evolve`) + auto-invoked lens skills
+- `scripts/` — Python helpers invoked via shell from skill bodies
 - `agents/` — subagents for drift classification and evolve proposals
-- `skills/` — auto-invoked lens skills
 - `hooks/` — optional `SessionStart` brief injection
 
 ## Config file
 
-Projects opt in by creating `.compass.yaml` at their root. See
-`docs/config.md` (planned v0.1.0) for the schema.
+Projects opt in by creating `.compass.toml` at their root. See
+[`docs/config.md`](../../docs/config.md) for the schema.
 
 ## License
 

--- a/plugins/compass/README.md
+++ b/plugins/compass/README.md
@@ -2,35 +2,97 @@
 
 Direction-first audit lens for Claude Code projects.
 
-> This is the plugin body. For the philosophy and roadmap, see the
+> Plugin body. For philosophy and roadmap, see the
 > [marketplace README](../../README.md), [VISION.md](../../VISION.md)
 > and [ROADMAP.md](../../ROADMAP.md) at the repository root.
 
 ## What it does
 
-Compass measures how well recent work on your project serves its declared
+Compass measures how well recent work serves your project's declared
 **pillars** (3–5 things that matter most). It surfaces **drift** (work
-happening outside the pillars) and proposes the smallest realignment step.
+happening outside the pillars) and proposes the smallest realignment
+step.
 
-It composes with other audit plugins instead of duplicating them.
+Composes with other audit plugins instead of duplicating them.
 
 ## Status
 
-**Pre-alpha (v0.0.1).** Scaffolding only — no commands implemented yet.
-See [ROADMAP.md](../../ROADMAP.md) for milestones.
+**v0.1.0 — MVP "Pillars & Direction"**. Two slash commands shipped:
 
-## Components (target, not yet shipped)
+- `/compass:init` — interactive setup of `.compass.toml`
+- `/compass:check` — Direction Index + pillar coverage + drift signals
 
-- `skills/` — slash commands implemented as `SKILL.md` (namespaced
-  `/compass:init|check|boot|drift|evolve`) + auto-invoked lens skills
-- `scripts/` — Python helpers invoked via shell from skill bodies
-- `agents/` — subagents for drift classification and evolve proposals
-- `hooks/` — optional `SessionStart` brief injection
+Plus an auto-invoked skill `/compass:lens` that runs `check` when the
+user asks "where am I going" / "am I on track" / "sono sulla strada
+giusta".
+
+## Commands
+
+### `/compass:init`
+
+Inspects the repo (top-level dirs, README, project type signals),
+proposes 3–5 pillars based on detected project type, walks you through
+confirming/editing each one, then writes `.compass.toml` at the repo
+root. Refuses to overwrite an existing config.
+
+Runs `scripts/init.py inspect` to gather data, then `scripts/init.py
+write` to commit the validated TOML.
+
+### `/compass:check`
+
+Reads `.compass.toml`, classifies the last N commits per category
+(Core/Tests/Docs/Infra/Tooling/Other) using the path globs declared in
+your pillars, computes the **Direction Index** with the formula in
+[VISION.md §1](../../VISION.md), and prints a ≤40-line markdown briefing:
+
+- DI score and verdict (rotta coerente / attenzione / deriva)
+- Decomposed breakdown table (3 components, weighted contributions)
+- Pillar checklist (touched / untouched in window)
+- Top 3 drift signals (ranked by impact)
+- Single next-smallest-step suggestion
+
+Runs `scripts/check.py`.
+
+### `/compass:lens` (auto-invoked skill)
+
+Triggered by phrases like "am I on track", "where am I going", "check
+the project" — runs `/compass:check` and presents the briefing
+verbatim.
+
+## Components
+
+- `skills/compass-init/SKILL.md` — `/compass:init`
+- `skills/compass-check/SKILL.md` — `/compass:check`
+- `skills/compass-lens/SKILL.md` — auto-invoked lens
+- `scripts/check.py`, `scripts/init.py` — Python entry points called
+  from skills via shell injection
+- `lib/` — internal modules (config parser, classifier, git reader,
+  direction calculator, briefing renderer)
+- `agents/`, `hooks/` — empty, reserved for v0.2.0+
 
 ## Config file
 
 Projects opt in by creating `.compass.toml` at their root. See
-[`docs/config.md`](../../docs/config.md) for the schema.
+[`docs/config.md`](../../docs/config.md) for the full schema (TOML 1.0,
+parsed by `tomllib` from Python stdlib ≥ 3.11).
+
+Minimal valid config:
+
+```toml
+version = 1
+
+[[pillars]]
+id = "core"
+name = "Core product"
+paths = ["src/**"]
+```
+
+## Requirements
+
+- Python ≥ 3.11 (for `tomllib`)
+- `git` CLI in `PATH`
+- `gh` CLI optional (for `[issues] enabled = true`); without it,
+  issue_factor neutralizes to 0.5
 
 ## License
 

--- a/plugins/compass/commands/.gitkeep
+++ b/plugins/compass/commands/.gitkeep
@@ -1,2 +1,0 @@
-# Placeholder - commands will be populated starting v0.1.0
-# See ../../ROADMAP.md

--- a/plugins/compass/lib/__init__.py
+++ b/plugins/compass/lib/__init__.py
@@ -1,0 +1,2 @@
+"""Compass plugin internal library. Stdlib-only."""
+__version__ = "0.1.0"

--- a/plugins/compass/lib/classify.py
+++ b/plugins/compass/lib/classify.py
@@ -1,0 +1,101 @@
+"""Classify files and commits against pillars + categories. Spec: docs/config.md §5-§6."""
+from __future__ import annotations
+
+import fnmatch
+import re
+from dataclasses import dataclass, field
+from typing import Any
+
+from .config import CATEGORY_ORDER
+
+
+@dataclass
+class FileHit:
+    path: str
+    category: str
+    pillar_id: str | None
+    weight: float
+
+
+@dataclass
+class CommitHit:
+    sha: str
+    message: str
+    files: list[FileHit] = field(default_factory=list)
+    dominant_category: str | None = None
+    verified: bool = True
+
+
+def _glob_match(path: str, pat: str) -> bool:
+    """fnmatch with ** support (any number of segments)."""
+    if "**" not in pat:
+        return fnmatch.fnmatchcase(path, pat)
+    parts: list[str] = []
+    i = 0
+    while i < len(pat):
+        c = pat[i]
+        if c == "*" and i + 1 < len(pat) and pat[i + 1] == "*":
+            parts.append(".*")
+            i += 2
+            if i < len(pat) and pat[i] == "/":
+                i += 1
+        elif c == "*":
+            parts.append("[^/]*"); i += 1
+        elif c == "?":
+            parts.append("[^/]"); i += 1
+        elif c in ".+^$()[]{}|\\":
+            parts.append(re.escape(c)); i += 1
+        else:
+            parts.append(c); i += 1
+    return re.match("^" + "".join(parts) + "$", path) is not None
+
+
+def _match_any(path: str, patterns: list[str]) -> bool:
+    return any(_glob_match(path, p) for p in patterns)
+
+
+def is_ignored(path: str, ignore_patterns: list[str]) -> bool:
+    return _match_any(path, ignore_patterns)
+
+
+def classify_file(path: str, cfg: dict[str, Any]) -> FileHit:
+    """Resolve path to FileHit. Pillars first (first-match wins), then categories, then 'other'."""
+    for p in cfg["pillars"]:
+        if _match_any(path, p["paths"]):
+            return FileHit(path, f"pillar:{p['id']}", p["id"],
+                           cfg["categories"]["core"]["weight"])
+    for cat_name in CATEGORY_ORDER:
+        cat = cfg["categories"][cat_name]
+        if _match_any(path, cat["paths"]):
+            return FileHit(path, cat_name, None, cat["weight"])
+    return FileHit(path, "other", None, 0.0)
+
+
+def _category_from_message(message: str, cfg: dict[str, Any]) -> str | None:
+    line = message.splitlines()[0] if message else ""
+    for cat_name in CATEGORY_ORDER:
+        for pat in cfg["categories"][cat_name]["message_patterns"]:
+            try:
+                if re.search(pat, line):
+                    return cat_name
+            except re.error:
+                continue
+    return None
+
+
+def classify_commit(commit: dict[str, Any], cfg: dict[str, Any]) -> CommitHit:
+    """Classify commit's files + resolve dominant category + verify against message."""
+    hits = [classify_file(f, cfg) for f in commit.get("files", [])
+            if not is_ignored(f, cfg["ignore"])]
+    ch = CommitHit(sha=commit["sha"], message=commit.get("message", ""), files=hits)
+    if not hits:
+        return ch
+    weights: dict[str, float] = {}
+    for h in hits:
+        key = "core" if h.category.startswith("pillar:") else h.category
+        weights[key] = weights.get(key, 0.0) + abs(h.weight)
+    ch.dominant_category = max(weights.items(), key=lambda kv: kv[1])[0]
+    msg_cat = _category_from_message(ch.message, cfg)
+    if msg_cat is not None and msg_cat != ch.dominant_category:
+        ch.verified = False
+    return ch

--- a/plugins/compass/lib/config.py
+++ b/plugins/compass/lib/config.py
@@ -1,0 +1,150 @@
+"""Load, validate, default-fill .compass.toml. Spec: docs/config.md."""
+from __future__ import annotations
+
+import re
+import tomllib
+from pathlib import Path
+from typing import Any
+
+SCHEMA_VERSION = 1
+VALID_PROJECT_TYPES = {"game-dev", "web-saas", "research", "library", "docs", "other"}
+PILLAR_ID_RE = re.compile(r"^[a-z][a-z0-9-]{1,40}$")
+
+
+class ConfigError(ValueError):
+    """Raised on invalid .compass.toml content."""
+
+
+_CAT_DEFAULTS = (
+    ("core",    [], 1.0),
+    ("tests",   ["tests/**", "**/*_test.py", "**/*.test.*", "**/*.spec.*"], 0.5),
+    ("docs",    ["docs/**", "**/*.md", "README*", "LICENSE*"], 0.3),
+    ("infra",   [".github/**", "Dockerfile*", "docker-compose*", "ci/**",
+                 ".gitlab-ci.yml", "Makefile"], -0.1),
+    ("tooling", ["scripts/**", "tools/**", ".pre-commit-config.yaml"], 0.0),
+)
+DEFAULTS: dict[str, Any] = {
+    "project": {"name": None, "type": "other"},
+    "categories": {n: {"paths": p, "weight": w, "message_patterns": []}
+                   for n, p, w in _CAT_DEFAULTS},
+    "direction": {"window": 30,
+                  "formula": {"core_share": 0.4, "pillar_coverage": 0.4, "issue_factor": 0.2},
+                  "thresholds": {"healthy": 60, "warning": 40}},
+    "issues": {"enabled": False, "closed_window_days": 30},
+    "ignore": [".git/**", "node_modules/**", "**/__pycache__/**",
+               "*.lock", "dist/**", "build/**"],
+    "evolve": {"enabled": False},
+    "delegate_to": [],
+}
+
+CATEGORY_ORDER = tuple(n for n, _, _ in _CAT_DEFAULTS)
+
+
+def load(path: Path) -> dict[str, Any]:
+    """Read + parse + validate + default-fill. Raises ConfigError on bad data."""
+    if not path.exists():
+        raise ConfigError(f"config not found: {path}")
+    try:
+        with path.open("rb") as f:
+            raw = tomllib.load(f)
+    except tomllib.TOMLDecodeError as e:
+        raise ConfigError(f"{path}: TOML parse error: {e}") from e
+    cfg = _merge_defaults(raw)
+    _validate(cfg, path)
+    return cfg
+
+
+def _merge_defaults(raw: dict[str, Any]) -> dict[str, Any]:
+    out: dict[str, Any] = {
+        "version": raw.get("version"),
+        "pillars": list(raw.get("pillars", [])),
+        "project": {**DEFAULTS["project"], **raw.get("project", {})},
+        "direction": _deep_merge(DEFAULTS["direction"], raw.get("direction", {})),
+        "issues": {**DEFAULTS["issues"], **raw.get("issues", {})},
+        "ignore": list(raw.get("ignore", DEFAULTS["ignore"])),
+        "evolve": {**DEFAULTS["evolve"], **raw.get("evolve", {})},
+        "delegate_to": list(raw.get("delegate_to", [])),
+        "categories": {},
+    }
+    raw_cats = raw.get("categories", {})
+    for name, default in DEFAULTS["categories"].items():
+        user = raw_cats.get(name, {})
+        out["categories"][name] = {
+            "paths": list(user.get("paths", default["paths"])),
+            "weight": float(user.get("weight", default["weight"])),
+            "message_patterns": list(user.get("message_patterns", default["message_patterns"])),
+        }
+    return out
+
+
+def _deep_merge(base: dict[str, Any], override: dict[str, Any]) -> dict[str, Any]:
+    out = dict(base)
+    for k, v in override.items():
+        if isinstance(v, dict) and isinstance(out.get(k), dict):
+            out[k] = _deep_merge(out[k], v)
+        else:
+            out[k] = v
+    return out
+
+
+def _err(path: Path, msg: str) -> None:
+    raise ConfigError(f"{path}: {msg}")
+
+
+def _validate(cfg: dict[str, Any], path: Path) -> None:
+    if cfg.get("version") != SCHEMA_VERSION:
+        _err(path, f"version must be {SCHEMA_VERSION} (got {cfg.get('version')!r})")
+    pillars = cfg["pillars"]
+    if not isinstance(pillars, list) or not 1 <= len(pillars) <= 10:
+        _err(path, f"pillars must be 1..10 entries (got {len(pillars)})")
+    seen: set[str] = set()
+    for i, p in enumerate(pillars):
+        if not isinstance(p, dict):
+            _err(path, f"pillars[{i}] must be a table")
+        pid = p.get("id", "")
+        if not isinstance(pid, str) or not PILLAR_ID_RE.match(pid):
+            _err(path, f"pillars[{i}].id invalid kebab-case: {pid!r}")
+        if pid in seen:
+            _err(path, f"pillars[{i}].id duplicate: {pid!r}")
+        seen.add(pid)
+        paths = p.get("paths", [])
+        if not isinstance(paths, list) or not paths or not all(isinstance(x, str) and x for x in paths):
+            _err(path, f"pillars[{i}].paths must be non-empty list of strings")
+        w = p.get("weight", 1.0)
+        if not isinstance(w, (int, float)) or not 0.0 <= w <= 10.0:
+            _err(path, f"pillars[{i}].weight out of [0.0, 10.0]: {w!r}")
+        p["weight"] = float(w)
+        p.setdefault("name", pid)
+        p.setdefault("description", "")
+    ptype = cfg["project"].get("type", "other")
+    if ptype not in VALID_PROJECT_TYPES:
+        _err(path, f"project.type invalid: {ptype!r}")
+    d = cfg["direction"]
+    if not isinstance(d["window"], int) or not 5 <= d["window"] <= 500:
+        _err(path, f"direction.window out of [5,500]: {d['window']!r}")
+    f = d["formula"]
+    total = f["core_share"] + f["pillar_coverage"] + f["issue_factor"]
+    if abs(total - 1.0) > 0.001:
+        _err(path, f"direction.formula weights must sum to 1.0 (got {total:.4f})")
+    t = d["thresholds"]
+    if not 0 <= t["warning"] < t["healthy"] <= 100:
+        _err(path, f"direction.thresholds invalid: warning={t['warning']} healthy={t['healthy']}")
+    for name, cat in cfg["categories"].items():
+        cw = cat["weight"]
+        if not isinstance(cw, (int, float)) or not -1.0 <= cw <= 2.0:
+            _err(path, f"categories.{name}.weight out of [-1.0, 2.0]: {cw!r}")
+        for pat in cat["message_patterns"]:
+            try:
+                re.compile(pat)
+            except re.error as e:
+                _err(path, f"categories.{name}.message_patterns invalid regex {pat!r}: {e}")
+
+
+def find_config(start: Path) -> Path | None:
+    """Walk up from start looking for .compass.toml. Returns path or None."""
+    cur = start.resolve()
+    for parent in (cur, *cur.parents):
+        candidate = parent / ".compass.toml"
+        if candidate.exists():
+            return candidate
+    return None

--- a/plugins/compass/lib/direction.py
+++ b/plugins/compass/lib/direction.py
@@ -1,0 +1,114 @@
+"""Compute Direction Index from classified commits. Spec: docs/config.md §6, §9."""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any
+
+from .classify import CommitHit
+
+
+@dataclass
+class DirectionResult:
+    score: float
+    core_share: float
+    core_contrib: float
+    pillar_coverage: float
+    pillar_contrib: float
+    issue_factor: float
+    issue_contrib: float
+    pillars_touched: dict[str, int]
+    pillars_total: int
+    category_counts: dict[str, int]
+    window: int
+    issues_enabled: bool
+
+
+def compute(commits: list[CommitHit], cfg: dict[str, Any],
+            issues: dict[str, int] | None) -> DirectionResult:
+    pillar_ids = [p["id"] for p in cfg["pillars"]]
+    pillars_total = len(pillar_ids)
+    sum_core = 0.0
+    sum_abs = 0.0
+    pillars_touched: dict[str, int] = {pid: 0 for pid in pillar_ids}
+    category_counts: dict[str, int] = {}
+
+    for ch in commits:
+        verify_mult = 1.0 if ch.verified else 0.5
+        commit_pillars: set[str] = set()
+        for fh in ch.files:
+            w = fh.weight * verify_mult
+            sum_abs += abs(w)
+            if fh.category.startswith("pillar:") or fh.category == "core":
+                sum_core += w
+            if fh.pillar_id is not None:
+                commit_pillars.add(fh.pillar_id)
+        for pid in commit_pillars:
+            pillars_touched[pid] += 1
+        if ch.dominant_category:
+            category_counts[ch.dominant_category] = category_counts.get(ch.dominant_category, 0) + 1
+
+    core_share = max(0.0, min(1.0, sum_core / sum_abs if sum_abs > 0 else 0.0))
+    pillar_coverage = (sum(1 for pid in pillar_ids if pillars_touched[pid] > 0) / pillars_total) \
+        if pillars_total else 0.0
+    if issues is not None:
+        total = issues["open"] + issues["closed"]
+        issue_factor = issues["closed"] / total if total > 0 else 0.5
+        issues_enabled = True
+    else:
+        issue_factor = 0.5
+        issues_enabled = False
+
+    f = cfg["direction"]["formula"]
+    core_contrib = core_share * 100 * f["core_share"]
+    pillar_contrib = pillar_coverage * 100 * f["pillar_coverage"]
+    issue_contrib = issue_factor * 100 * f["issue_factor"]
+    score = core_contrib + pillar_contrib + issue_contrib
+
+    return DirectionResult(
+        score=round(score, 1), core_share=core_share, core_contrib=round(core_contrib, 1),
+        pillar_coverage=pillar_coverage, pillar_contrib=round(pillar_contrib, 1),
+        issue_factor=issue_factor, issue_contrib=round(issue_contrib, 1),
+        pillars_touched=pillars_touched, pillars_total=pillars_total,
+        category_counts=category_counts, window=len(commits), issues_enabled=issues_enabled,
+    )
+
+
+def drift_signals(result: DirectionResult, commits: list[CommitHit],
+                  cfg: dict[str, Any]) -> list[str]:
+    """Top 3 drift signals (one-liners), ordered by impact on score."""
+    f = cfg["direction"]["formula"]
+    sigs: list[tuple[float, str]] = []
+    n_commits = len(commits)
+    for pid, n in result.pillars_touched.items():
+        if n == 0:
+            sigs.append((f["pillar_coverage"] * 100 / max(1, result.pillars_total),
+                         f"`{pid}` non toccato in {result.window} commit"))
+    infra_n = result.category_counts.get("infra", 0)
+    if n_commits and infra_n / n_commits > 0.3:
+        sigs.append((8.0, f"{round(infra_n/n_commits*100)}% commit dominanti `infra` (soglia <30%)"))
+    if result.core_share < 0.2 and result.window >= 10:
+        sigs.append(((0.4 - result.core_share) * 100 * f["core_share"],
+                     f"`core_share` solo {round(result.core_share*100)}% in window"))
+    p_idx = [i for i, ch in enumerate(commits) if any(fh.pillar_id for fh in ch.files)]
+    if p_idx and p_idx[0] > result.window // 2:
+        sigs.append((5.0, f"ultimo commit core a {p_idx[0]} commit fa"))
+    ambig = sum(1 for ch in commits if not ch.verified)
+    if ambig >= 3:
+        sigs.append((3.0, f"{ambig} commit con messaggio in conflitto coi file toccati"))
+    sigs.sort(key=lambda x: x[0], reverse=True)
+    return [s for _, s in sigs[:3]]
+
+
+def next_smallest_step(result: DirectionResult, cfg: dict[str, Any]) -> str | None:
+    """Suggest a single concrete next action, smallest possible."""
+    untouched = [pid for pid, n in result.pillars_touched.items() if n == 0]
+    if untouched:
+        pid = untouched[0]
+        for p in cfg["pillars"]:
+            if p["id"] == pid:
+                paths = p.get("paths") or []
+                hint = paths[0] if paths else "(no paths declared)"
+                return (f"Apri un commit su `{pid}`. Path più promettente: `{hint}`.")
+    if result.core_share < 0.3 and result.window >= 5:
+        return "Prossimo commit: tocca un file dentro un pilastro dichiarato."
+    return None

--- a/plugins/compass/lib/git.py
+++ b/plugins/compass/lib/git.py
@@ -1,0 +1,102 @@
+"""Read recent commits via `git` CLI. No external deps."""
+from __future__ import annotations
+
+import subprocess
+from pathlib import Path
+from typing import Any
+
+
+class GitError(RuntimeError):
+    """Raised on git CLI errors."""
+
+
+def _run(args: list[str], cwd: Path) -> str:
+    try:
+        out = subprocess.run(
+            ["git", *args], cwd=cwd, check=True, capture_output=True, text=True
+        )
+    except FileNotFoundError as e:
+        raise GitError("git CLI not found in PATH") from e
+    except subprocess.CalledProcessError as e:
+        raise GitError(f"git {' '.join(args)} failed: {e.stderr.strip()}") from e
+    return out.stdout
+
+
+def repo_root(start: Path) -> Path:
+    """Resolve git repo root from `start`. Raises GitError if not a repo."""
+    out = _run(["rev-parse", "--show-toplevel"], cwd=start).strip()
+    if not out:
+        raise GitError(f"{start} is not inside a git repo")
+    return Path(out)
+
+
+def recent_commits(repo: Path, window: int) -> list[dict[str, Any]]:
+    """Return last `window` commits, each as {sha, author, ts, message, files}.
+
+    Uses `git log -n <window> --name-only --format=...` with a unique record
+    delimiter so multiline messages parse safely.
+    """
+    sep = "\x1ecompassREC\x1e"
+    field = "\x1ecompassFLD\x1e"
+    fmt = field.join(["%H", "%an", "%at", "%s%n%b"])
+    raw = _run(
+        ["log", f"-n{window}", "--name-only",
+         f"--pretty=format:{sep}{fmt}{sep}"],
+        cwd=repo,
+    )
+    commits: list[dict[str, Any]] = []
+    chunks = raw.split(sep)
+    # chunks alternate: ["", header1, files1, header2, files2, ...]
+    i = 1
+    while i < len(chunks):
+        header = chunks[i]
+        files_blob = chunks[i + 1] if i + 1 < len(chunks) else ""
+        i += 2
+        parts = header.split(field, 3)
+        if len(parts) < 4:
+            continue
+        sha, author, ts, message = parts
+        files = [ln.strip() for ln in files_blob.splitlines() if ln.strip()]
+        commits.append({
+            "sha": sha.strip(),
+            "author": author,
+            "ts": int(ts) if ts.isdigit() else 0,
+            "message": message.strip("\n"),
+            "files": files,
+        })
+    return commits
+
+
+def issues_summary(repo: Path, window_days: int) -> dict[str, int] | None:
+    """Use `gh issue list` to count open + recently closed issues.
+
+    Returns None if `gh` is missing or fails (caller falls back to neutral).
+    """
+    try:
+        open_out = subprocess.run(
+            ["gh", "issue", "list", "--state", "open", "--limit", "500",
+             "--json", "number"],
+            cwd=repo, check=True, capture_output=True, text=True,
+        )
+        closed_out = subprocess.run(
+            ["gh", "issue", "list", "--state", "closed", "--limit", "500",
+             "--search", f"closed:>={_iso_days_ago(window_days)}",
+             "--json", "number"],
+            cwd=repo, check=True, capture_output=True, text=True,
+        )
+    except (FileNotFoundError, subprocess.CalledProcessError):
+        return None
+    import json
+    try:
+        n_open = len(json.loads(open_out.stdout))
+        n_closed = len(json.loads(closed_out.stdout))
+    except (ValueError, TypeError):
+        return None
+    return {"open": n_open, "closed": n_closed}
+
+
+def _iso_days_ago(days: int) -> str:
+    """ISO date `days` ago, format YYYY-MM-DD."""
+    from datetime import datetime, timedelta, timezone
+    d = datetime.now(timezone.utc) - timedelta(days=days)
+    return d.strftime("%Y-%m-%d")

--- a/plugins/compass/lib/output.py
+++ b/plugins/compass/lib/output.py
@@ -1,0 +1,76 @@
+"""Render the /compass:check briefing markdown. Spec: docs/config.md §9."""
+from __future__ import annotations
+
+from datetime import date
+from typing import Any
+
+from .direction import DirectionResult, drift_signals, next_smallest_step
+from .classify import CommitHit
+
+
+def render_briefing(result: DirectionResult, commits: list[CommitHit],
+                    cfg: dict[str, Any]) -> str:
+    f = cfg["direction"]["formula"]
+    t = cfg["direction"]["thresholds"]
+
+    if result.score >= t["healthy"]:
+        verdict = "rotta coerente"
+    elif result.score < t["warning"]:
+        verdict = "deriva evidente"
+    else:
+        verdict = "attenzione"
+
+    issue_val = (f"{result.issue_factor:.2f}"
+                 if result.issues_enabled else "n/d (off)")
+
+    lines: list[str] = []
+    lines.append("# Compass — Direction check\n")
+    lines.append(
+        f"**Direction Index: {result.score:.0f} / 100** "
+        f"({verdict}) · window: {result.window} commits · "
+        f"generated: {date.today().isoformat()}\n"
+    )
+    lines.append("## Breakdown\n")
+    lines.append("| Componente       | Peso | Valore | Contributo |")
+    lines.append("|------------------|-----:|-------:|-----------:|")
+    lines.append(
+        f"| Core share       | {f['core_share']:.2f} | "
+        f"{result.core_share*100:5.0f}% | {result.core_contrib:>10.1f} |"
+    )
+    touched = sum(1 for n in result.pillars_touched.values() if n > 0)
+    lines.append(
+        f"| Pillar coverage  | {f['pillar_coverage']:.2f} | "
+        f"  {touched}/{result.pillars_total} | {result.pillar_contrib:>10.1f} |"
+    )
+    lines.append(
+        f"| Issue factor     | {f['issue_factor']:.2f} | "
+        f"{issue_val:>6} | {result.issue_contrib:>10.1f} |"
+    )
+    lines.append("")
+
+    lines.append("## Pilastri nel window")
+    if not result.pillars_touched:
+        lines.append("- (nessun pilastro dichiarato)")
+    else:
+        for p in cfg["pillars"]:
+            pid = p["id"]
+            n = result.pillars_touched.get(pid, 0)
+            mark = "[x]" if n > 0 else "[ ]"
+            label = f"`{pid}`" if n > 0 else f"**`{pid}`** ← 0 commit"
+            suffix = f" ({n} commit)" if n > 0 else ""
+            lines.append(f"- {mark} {label}{suffix}")
+    lines.append("")
+
+    signals = drift_signals(result, commits, cfg)
+    lines.append("## Drift signals (ranked)")
+    if not signals:
+        lines.append("- Nessun segnale di deriva sopra la soglia. ✓")
+    else:
+        for i, s in enumerate(signals, 1):
+            lines.append(f"{i}. {s}")
+    lines.append("")
+
+    step = next_smallest_step(result, cfg)
+    lines.append("## Next smallest step")
+    lines.append(step if step else "Nessuna correzione urgente. Continua.")
+    return "\n".join(lines).rstrip() + "\n"

--- a/plugins/compass/scripts/check.py
+++ b/plugins/compass/scripts/check.py
@@ -1,0 +1,71 @@
+#!/usr/bin/env python3
+"""Entry point for /compass:check. Reads .compass.toml, computes Direction Index,
+prints markdown briefing on stdout. Exits non-zero on config errors."""
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+# Force UTF-8 on stdout/stderr (Windows defaults to cp1252).
+for _stream in (sys.stdout, sys.stderr):
+    if hasattr(_stream, "reconfigure"):
+        try:
+            _stream.reconfigure(encoding="utf-8")
+        except (OSError, ValueError):
+            pass
+
+# Allow running from anywhere: add plugin root to sys.path so `lib.*` resolves.
+_HERE = Path(__file__).resolve().parent
+_PLUGIN_ROOT = _HERE.parent
+if str(_PLUGIN_ROOT) not in sys.path:
+    sys.path.insert(0, str(_PLUGIN_ROOT))
+
+from lib import config as cfgmod  # noqa: E402
+from lib import git as gitmod     # noqa: E402
+from lib.classify import classify_commit  # noqa: E402
+from lib.direction import compute  # noqa: E402
+from lib.output import render_briefing  # noqa: E402
+
+
+def main(argv: list[str]) -> int:
+    cwd = Path.cwd()
+    try:
+        repo = gitmod.repo_root(cwd)
+    except gitmod.GitError as e:
+        print(f"ERROR: {e}", file=sys.stderr)
+        return 2
+
+    cfg_path = cfgmod.find_config(repo)
+    if cfg_path is None:
+        print(
+            "ERROR: no .compass.toml found in repo. Run /compass:init first.",
+            file=sys.stderr,
+        )
+        return 3
+
+    try:
+        cfg = cfgmod.load(cfg_path)
+    except cfgmod.ConfigError as e:
+        print(f"ERROR: {e}", file=sys.stderr)
+        return 4
+
+    window = cfg["direction"]["window"]
+    try:
+        commits_raw = gitmod.recent_commits(repo, window)
+    except gitmod.GitError as e:
+        print(f"ERROR: {e}", file=sys.stderr)
+        return 5
+
+    commits = [classify_commit(c, cfg) for c in commits_raw]
+
+    issues = None
+    if cfg["issues"]["enabled"]:
+        issues = gitmod.issues_summary(repo, cfg["issues"]["closed_window_days"])
+
+    result = compute(commits, cfg, issues)
+    sys.stdout.write(render_briefing(result, commits, cfg))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main(sys.argv[1:]))

--- a/plugins/compass/scripts/init.py
+++ b/plugins/compass/scripts/init.py
@@ -1,0 +1,180 @@
+#!/usr/bin/env python3
+"""Helpers for /compass:init. Two subcommands:
+  inspect              Print JSON summary of the current repo (top-dirs,
+                       README presence, detected language hints, project
+                       type guess, suggested pillars).
+  write <toml-file>    Validate the proposed TOML config and write it to
+                       .compass.toml at the repo root. Emits OK/ERROR.
+
+The interactive Q&A is driven by Claude reading inspect output and
+proposing pillars to the user; this script is a pure utility."""
+from __future__ import annotations
+
+import json
+import sys
+import tomllib
+from pathlib import Path
+
+_HERE = Path(__file__).resolve().parent
+_PLUGIN_ROOT = _HERE.parent
+if str(_PLUGIN_ROOT) not in sys.path:
+    sys.path.insert(0, str(_PLUGIN_ROOT))
+
+from lib import config as cfgmod  # noqa: E402
+from lib import git as gitmod     # noqa: E402
+
+PROJECT_TYPE_BY_SIGNALS: list[tuple[str, list[str]]] = [
+    ("game-dev", ["assets", "scenes", "godot.project", "Game.uproject",
+                  "ProjectSettings/", "package.json:phaser", "Cargo.toml:bevy"]),
+    ("web-saas", ["next.config.js", "next.config.ts", "remix.config.js",
+                  "package.json:next", "package.json:remix"]),
+    ("library",  ["pyproject.toml", "setup.py", "Cargo.toml",
+                  "package.json:main", "go.mod"]),
+    ("research", ["notebooks/", "*.ipynb", "data/raw/", "experiments/"]),
+    ("docs",     ["mkdocs.yml", "docusaurus.config.js", "_config.yml", "book.toml"]),
+]
+
+# (id, name, paths) tuples per project type. Pillars whose paths don't match
+# anything in repo are dropped at suggestion time.
+DEFAULT_PILLAR_TEMPLATES: dict[str, list[tuple[str, str, list[str]]]] = {
+    "game-dev": [
+        ("gameplay-core", "Gameplay & feel", ["src/game/**", "scenes/**", "assets/**"]),
+        ("balance-data", "Balance & data", ["data/**", "balance/**"]),
+        ("tactics-readability", "Lettura tattica UI", ["ui/**", "hud/**"]),
+    ],
+    "web-saas": [
+        ("core-funnel", "Core funnel", ["app/(main)/**", "src/pages/**"]),
+        ("perf-reliability", "Performance & reliability", ["src/lib/**", "src/server/**"]),
+        ("onboarding", "Onboarding", ["src/onboarding/**", "app/(onboarding)/**"]),
+    ],
+    "library": [
+        ("api-stability", "API stability", ["src/**", "lib/**"]),
+        ("examples", "Examples & docs", ["examples/**", "docs/**"]),
+        ("compat-perf", "Compatibility & perf", ["benches/**", "tests/perf/**"]),
+    ],
+    "research": [
+        ("experiments", "Experiments", ["experiments/**", "notebooks/**"]),
+        ("writeup", "Writeup & figures", ["paper/**", "figures/**"]),
+        ("reproducibility", "Reproducibility", ["env/**", "scripts/**"]),
+    ],
+    "docs": [
+        ("content", "Content", ["docs/**", "src/**"]),
+        ("navigation", "Navigation & IA", ["mkdocs.yml", "_config.yml", "sidebars.*"]),
+    ],
+    "other": [("core", "Core", ["src/**"])],
+}
+
+
+def _signal_match(repo: Path, sig: str) -> bool:
+    if ":" in sig:
+        fname, needle = sig.split(":", 1)
+        f = repo / fname
+        try:
+            return f.exists() and needle in f.read_text(encoding="utf-8", errors="ignore")
+        except OSError:
+            return False
+    if "*" in sig or "?" in sig:
+        return bool(list(repo.glob(sig)))
+    if sig.endswith("/"):
+        return (repo / sig.rstrip("/")).is_dir()
+    return (repo / sig).exists()
+
+
+def _detect_project_type(repo: Path) -> str:
+    for ptype, signals in PROJECT_TYPE_BY_SIGNALS:
+        if any(_signal_match(repo, s) for s in signals):
+            return ptype
+    return "other"
+
+
+def _top_dirs(repo: Path) -> list[str]:
+    skip = {".git", "node_modules", "__pycache__", "dist", "build", ".venv", "venv"}
+    return [c.name for c in sorted(repo.iterdir())
+            if c.is_dir() and c.name not in skip and not c.name.startswith(".")]
+
+
+def _suggest_pillars(repo: Path, ptype: str) -> list[dict]:
+    template = DEFAULT_PILLAR_TEMPLATES.get(ptype, DEFAULT_PILLAR_TEMPLATES["other"])
+    suggested: list[dict] = []
+    for pid, name, paths in template:
+        kept = [p for p in paths if _has_match(repo, p)]
+        if kept:
+            suggested.append({"id": pid, "name": name, "paths": kept})
+    if not suggested:
+        dirs = _top_dirs(repo)
+        if dirs:
+            suggested.append({"id": "core", "name": "Core", "paths": [f"{dirs[0]}/**"]})
+    return suggested
+
+
+def _has_match(repo: Path, pattern: str) -> bool:
+    """Cheap check: does any path in repo match this glob? Uses pathlib.glob."""
+    try:
+        # pathlib doesn't support ** without recursive flag; substitute.
+        pat = pattern.replace("**", "*")
+        return any(True for _ in repo.glob(pat))
+    except (OSError, ValueError):
+        return False
+
+
+def cmd_inspect(repo_arg: str | None) -> int:
+    cwd = Path.cwd() if repo_arg is None else Path(repo_arg).resolve()
+    try:
+        repo = gitmod.repo_root(cwd)
+    except gitmod.GitError as e:
+        print(json.dumps({"error": str(e)}))
+        return 2
+    ptype = _detect_project_type(repo)
+    info = {
+        "repo_root": str(repo),
+        "name": repo.name,
+        "project_type": ptype,
+        "top_dirs": _top_dirs(repo),
+        "has_readme": any((repo / n).exists() for n in ("README.md", "readme.md", "README.rst")),
+        "has_existing_config": (repo / ".compass.toml").exists(),
+        "suggested_pillars": _suggest_pillars(repo, ptype),
+    }
+    print(json.dumps(info, indent=2, ensure_ascii=False))
+    return 0
+
+
+def cmd_write(toml_file: str) -> int:
+    src = Path(toml_file).resolve()
+    if not src.exists():
+        print(f"ERROR: file not found: {src}", file=sys.stderr); return 2
+    try:
+        with src.open("rb") as f:
+            tomllib.load(f)
+    except tomllib.TOMLDecodeError as e:
+        print(f"ERROR: invalid TOML: {e}", file=sys.stderr); return 3
+    try:
+        cfg = cfgmod.load(src)
+    except cfgmod.ConfigError as e:
+        print(f"ERROR: schema validation failed: {e}", file=sys.stderr); return 4
+    try:
+        repo = gitmod.repo_root(Path.cwd())
+    except gitmod.GitError as e:
+        print(f"ERROR: {e}", file=sys.stderr); return 5
+    dst = repo / ".compass.toml"
+    if dst.exists():
+        print(f"ERROR: {dst} already exists. Remove it first to re-init.", file=sys.stderr)
+        return 6
+    dst.write_text(src.read_text(encoding="utf-8"), encoding="utf-8")
+    print(f"OK: wrote {dst} (pillars: {len(cfg['pillars'])})")
+    return 0
+
+
+def main(argv: list[str]) -> int:
+    if not argv:
+        print("usage: init.py inspect [REPO] | write TOMLFILE", file=sys.stderr); return 1
+    sub = argv[0]
+    if sub == "inspect":
+        return cmd_inspect(argv[1] if len(argv) > 1 else None)
+    if sub == "write" and len(argv) >= 2:
+        return cmd_write(argv[1])
+    print(f"ERROR: unknown or malformed subcommand {sub!r}", file=sys.stderr)
+    return 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main(sys.argv[1:]))

--- a/plugins/compass/skills/.gitkeep
+++ b/plugins/compass/skills/.gitkeep
@@ -1,2 +1,0 @@
-# Placeholder - skills will be populated starting v0.1.0
-# See ../../ROADMAP.md

--- a/plugins/compass/skills/compass-check/SKILL.md
+++ b/plugins/compass/skills/compass-check/SKILL.md
@@ -1,0 +1,20 @@
+---
+name: check
+description: Compute the project's Direction Index (0-100) and surface drift. Reads .compass.toml from the repo root and analyzes the last N commits. Use when the user asks "where am I going", "am I on track", "check the project", "direction check", "compass check".
+allowed-tools: Bash
+---
+
+Run the check script and present its output verbatim. The script reads
+`.compass.toml` at the repo root, classifies the last N commits per
+category (Core/Tests/Docs/Infra/Tooling/Other), and prints a markdown
+briefing with the Direction Index, breakdown table, pillar coverage, top
+drift signals, and the smallest next step.
+
+```!
+python3 "${CLAUDE_PLUGIN_ROOT}/scripts/check.py"
+```
+
+After the script output, do not summarize or rephrase. The briefing is
+the deliverable. If the script exits non-zero (no `.compass.toml`,
+malformed schema, not a git repo), surface the exact error and suggest
+running `/compass:init` first if the file is missing.

--- a/plugins/compass/skills/compass-init/SKILL.md
+++ b/plugins/compass/skills/compass-init/SKILL.md
@@ -1,0 +1,96 @@
+---
+name: init
+description: Interactively create .compass.toml for the current project. Inspects the repo, proposes 3-5 pillars based on detected project type, asks the user to confirm/edit each, then writes the file. Use when the user asks "init compass", "set up compass", "create compass config", "compass init", "/compass:init".
+allowed-tools: Bash, Read, Write
+---
+
+# /compass:init — interactive setup
+
+Goal: guide the user through creating a valid `.compass.toml` at the
+repo root. Schema spec: `docs/config.md`.
+
+## Step 1 — Inspect the repo
+
+Run the inspector to get a structured view:
+
+```!
+python3 "${CLAUDE_PLUGIN_ROOT}/scripts/init.py" inspect
+```
+
+The output is JSON with:
+
+- `repo_root`, `name`, `project_type` (auto-detected: game-dev, web-saas,
+  research, library, docs, or other)
+- `top_dirs` — top-level directories
+- `has_existing_config` — if true, **stop and tell the user** they
+  already have one. Don't overwrite without consent.
+- `suggested_pillars` — list of `{id, name, paths}` proposals filtered
+  against actual repo paths
+
+## Step 2 — Confirm with the user
+
+Present the inspector summary in plain language. Then walk through the
+suggested pillars **one at a time**, asking the user:
+
+> Pillar 1/3: `<id>` — `<name>`
+> Paths: `<paths>`
+>
+> Keep, edit, rename, or skip? (k/e/r/s)
+
+For each:
+- **k**: keep as-is
+- **e**: ask for revised paths (one per line)
+- **r**: ask for new id + name
+- **s**: drop the pillar
+
+After the proposed list, ask if they want to **add** a pillar that
+wasn't suggested. Cap total at 10. Require at least 1.
+
+If `project_type` was detected wrong, ask the user to override before
+walking pillars. The 6 valid types: game-dev, web-saas, research,
+library, docs, other.
+
+## Step 3 — Write the file
+
+Build the final TOML in memory using this exact structure (one
+`[[pillars]]` block per pillar, no extras beyond what was confirmed):
+
+```toml
+version = 1
+
+[project]
+name = "<repo name>"
+type = "<one of the 6 valid types>"
+
+[[pillars]]
+id = "<kebab-case>"
+name = "<human label>"
+description = "<optional, can be empty>"
+paths = ["<glob>", "..."]
+weight = 1.0
+```
+
+Show the user the final TOML and ask for one last confirm. On yes,
+write it via the helper (which validates and refuses to overwrite an
+existing `.compass.toml`):
+
+```
+python3 "${CLAUDE_PLUGIN_ROOT}/scripts/init.py" write /tmp/compass-proposed.toml
+```
+
+Where `/tmp/compass-proposed.toml` is the file you wrote with the
+agreed content. Use `Write` to create it before the shell call.
+
+## Step 4 — Next step
+
+After OK, suggest running `/compass:check` to see the first Direction
+Index. Don't run it automatically.
+
+## Constraints
+
+- Never overwrite an existing `.compass.toml`. Ask the user to remove
+  it manually first.
+- Never invent paths the user didn't confirm.
+- Stay within the schema in `docs/config.md`. Don't add fields the
+  validator will reject.
+- Keep the dialogue short: one question at a time, no walls of text.

--- a/plugins/compass/skills/compass-lens/SKILL.md
+++ b/plugins/compass/skills/compass-lens/SKILL.md
@@ -1,0 +1,38 @@
+---
+name: lens
+description: Direction-aware project lens. Use proactively when the user asks "where am I going", "am I on track", "is my work serving my goals", "sono sulla strada giusta", "dove sto andando", "check del progetto", or expresses doubt about whether recent commits matter. Triggers /compass:check under the hood.
+allowed-tools: Bash
+---
+
+# Compass lens — when the user wonders if they're drifting
+
+This skill is auto-invoked by Claude when the user asks direction-aware
+questions even without saying "compass" explicitly. Phrases that should
+trigger it:
+
+- "Where am I going with this project?"
+- "Am I on track?" / "Sono sulla strada giusta?"
+- "Is this work meaningful?" / "Sto andando da qualche parte?"
+- "Check the project" / "Fammi un check"
+- "Is the last week useful?"
+
+## What to do
+
+1. Check that `.compass.toml` exists at the repo root. If not, suggest
+   `/compass:init` and stop.
+2. Run the Direction Index briefing:
+
+   ```!
+   python3 "${CLAUDE_PLUGIN_ROOT}/scripts/check.py"
+   ```
+
+3. Present the briefing verbatim. Don't add interpretation unless the
+   user asks for it.
+4. If the user asks "what should I do next?", point at the **Next
+   smallest step** line in the briefing — that's already the answer.
+
+## What NOT to do
+
+- Don't compute the Index by hand. Use the script.
+- Don't narrate the breakdown table. The numbers speak.
+- Don't suggest a refactor or a sprint. Compass is a lens, not a plan.


### PR DESCRIPTION
## Summary

Ship v0.1.0 MVP "Pillars & Direction" per `ROADMAP.md`.

- `/compass:init` — interactive setup of `.compass.toml` (inspect repo → propose pillars → confirm → write).
- `/compass:check` — Direction Index 0–100 + decomposed breakdown + drift signals + next-smallest-step. Formula da `VISION.md §1`.
- `/compass:lens` — auto-invoked skill su frasi tipo "sono sulla strada giusta" / "where am I going".
- `docs/config.md` — schema TOML completo (10 sezioni). TOML scelto su YAML/JSON dopo ricerca: 0 parser code (stdlib `tomllib`), commenti, tipato, real spec.
- Bumped `plugin.json` + `marketplace.json` → 0.1.0.
- ROADMAP v0.1.0: 4/5 checkbox spuntati. Cross-project test pendente (self-test su `compass-marketplace` eseguito).

Decisioni atomiche documentate nei commit:
- `.compass.yaml` → `.compass.toml` (tutti i fonti-verità: VISION/ROADMAP/README/CLAUDE)
- `/compass <cmd>` → `/compass:<cmd>` (namespace forzato Claude Code)
- Python `3.8+` → `3.11+` in CLAUDE.md (richiesto da `tomllib`)

## Architettura

- `plugins/compass/lib/` (570 LOC) — config, classify (CODEOWNERS-style globs + ** support), git, direction, output
- `plugins/compass/scripts/` (226 LOC) — `check.py`, `init.py` (subcomandi: inspect / write)
- `plugins/compass/skills/{compass-init,compass-check,compass-lens}/SKILL.md` — frontmatter + shell injection a `${CLAUDE_PLUGIN_ROOT}/scripts/...`

Budget LOC: **796 / 800** Python totale. Stdlib only, zero pip.

## Test plan

Self-test su `compass-marketplace`:

- [x] `inspect` emette JSON con `project_type` + `suggested_pillars` filtrati su path reali
- [x] `write /tmp/compass-test.toml` valida + scrive `.compass.toml`
- [x] `check.py` produce briefing markdown 22 righe, DI 87/100, 3 pillar tutti toccati
- [x] Edge case: overwrite refused (`.compass.toml` esistente)
- [x] Edge case: invalid TOML → error con line/column
- [x] Edge case: schema violation (id non kebab-case) → error specifico
- [x] Edge case: no `.compass.toml` → suggerisce `/compass:init`
- [ ] Cross-project test: Evo-Tactics + 1 SaaS + 1 docs repo (rimanda a v0.1.1 patch)

## Files changed

3 commit:
- `858a1cf` docs(v0.1.0): schema + rename YAML→TOML fonti-verita (6 file)
- `9c8be97` feat(v0.1.0): core lib + scripts (9 file)
- `3a2ea4d` feat(v0.1.0): SKILL.md + bump versioni (8 file)

🤖 Generated with [Claude Code](https://claude.com/claude-code)