### PR TITLE
feat(v0.2.0): /compass:boot + SessionStart hook

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -6,7 +6,7 @@
   },
   "metadata": {
     "description": "Direction-first audit & kickoff lens for Claude Code projects. Born from Evo-Tactics design philosophy.",
-    "version": "0.1.0"
+    "version": "0.2.0"
   },
   "plugins": [
     {
@@ -15,7 +15,7 @@
         "source": "local",
         "path": "plugins/compass"
       },
-      "version": "0.1.0",
+      "version": "0.2.0",
       "description": "Direction Index + Pillars + Drift detection for any Claude Code project. Composes with existing audit plugins instead of duplicating them.",
       "category": "productivity",
       "keywords": [

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -55,13 +55,16 @@ produce un briefing sotto i 60 secondi con numeri reali.
 
 **Scope:** il comando di apertura sessione.
 
-- [ ] `/compass:boot` — sostituisce il vecchio `/kickoff` con una versione
+- [x] `/compass:boot` — sostituisce il vecchio `/kickoff` con una versione
       direction-aware
-- [ ] SessionStart hook opzionale, che inietta un mini-brief (3–5 righe)
+- [x] SessionStart hook opzionale, che inietta un mini-brief (3–5 righe)
       all'apertura di ogni sessione
-- [ ] Integrazione **opzionale** con `claude-md-management`: se installato
+- [x] Integrazione **opzionale** con `claude-md-management`: se installato
       e se `.compass.toml` lo permette, `boot` può chiederne l'invocazione
-- [ ] Escape hatch `skip boot` rispettato
+      (hint emesso quando `boot.delegate_claude_md = true` + `CLAUDE.md`
+      esiste; nessuna invocazione automatica)
+- [x] Escape hatch `skip boot` rispettato (`COMPASS_SKIP_BOOT=1` env var
+      o `boot.enabled = false`)
 
 **Criterio di done:** aprire una sessione dentro un progetto con Compass
 installato produce automaticamente un micro-brief di direzione. L'utente

--- a/docs/config.md
+++ b/docs/config.md
@@ -127,7 +127,18 @@ ignore = [
   "build/**",
 ]
 
-# Forward-compat. In v0.1.0 questi campi sono letti ma ignorati.
+# Boot — kickoff direzionale opzionale (v0.2.0+).
+[boot]
+enabled = true                   # SessionStart hook injects mini-brief?
+                                 # default true. False = hook silenzioso.
+delegate_claude_md = false       # se true e claude-md-management è
+                                 # installato, boot suggerisce di
+                                 # invocarlo quando il CLAUDE.md è stale.
+escape_env = "COMPASS_SKIP_BOOT" # nome env var che disabilita il hook
+                                 # per la sessione corrente (qualsiasi
+                                 # valore non vuoto skippa).
+
+# Forward-compat. v0.1.0+ legge ma ignora.
 [evolve]
 enabled = false                  # v0.4.0
 

--- a/plugins/compass/.claude-plugin/plugin.json
+++ b/plugins/compass/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://json.schemastore.org/claude-code-plugin.json",
   "name": "compass",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "description": "Direction-first audit lens for Claude Code projects. Measures how well recent work serves the project's pillars, surfaces drift, and runs adaptive kickoff protocols. Composes with claude-md-management, doctor-skill, and audit-project rather than duplicating them.",
   "author": {
     "name": "MasterDD-L34D"

--- a/plugins/compass/README.md
+++ b/plugins/compass/README.md
@@ -17,14 +17,15 @@ Composes with other audit plugins instead of duplicating them.
 
 ## Status
 
-**v0.1.0 — MVP "Pillars & Direction"**. Two slash commands shipped:
+**v0.2.0 — "Boot"**. Three slash commands + SessionStart hook:
 
 - `/compass:init` — interactive setup of `.compass.toml`
-- `/compass:check` — Direction Index + pillar coverage + drift signals
+- `/compass:check` — full Direction Index briefing
+- `/compass:boot` — 3-line mini-brief for kickoff
+- `SessionStart` hook — auto mini-brief on session open (opt-out via
+  `boot.enabled = false` or `COMPASS_SKIP_BOOT=1`)
 
-Plus an auto-invoked skill `/compass:lens` that runs `check` when the
-user asks "where am I going" / "am I on track" / "sono sulla strada
-giusta".
+Plus auto-invoked skill `/compass:lens` for "am I on track" queries.
 
 ## Commands
 
@@ -53,6 +54,29 @@ your pillars, computes the **Direction Index** with the formula in
 
 Runs `scripts/check.py`.
 
+### `/compass:boot`
+
+Direction-aware kickoff. Same data as `/compass:check`, condensed to
+3-5 lines:
+
+```
+🟢 Compass — DI 88/100 (rotta coerente) · pilastri 3/3 · window 30 commit
+⚠ <top drift signal, if any>
+→ <next smallest step, if applicable>
+```
+
+Wired to a `SessionStart` hook (`hooks/hooks.json`) that runs the same
+brief automatically on session open. The hook is silent (exit 0, no
+output) when:
+
+- the project hasn't opted in (no `.compass.toml`)
+- `boot.enabled = false` in config
+- `COMPASS_SKIP_BOOT` (or whatever `boot.escape_env` names) is set
+
+If `boot.delegate_claude_md = true` and `CLAUDE.md` exists, the brief
+includes a one-line hint suggesting `/claude-md:audit` (delegation,
+not duplication — see `claude-md-management` plugin).
+
 ### `/compass:lens` (auto-invoked skill)
 
 Triggered by phrases like "am I on track", "where am I going", "check
@@ -63,12 +87,14 @@ verbatim.
 
 - `skills/compass-init/SKILL.md` — `/compass:init`
 - `skills/compass-check/SKILL.md` — `/compass:check`
+- `skills/compass-boot/SKILL.md` — `/compass:boot`
 - `skills/compass-lens/SKILL.md` — auto-invoked lens
-- `scripts/check.py`, `scripts/init.py` — Python entry points called
-  from skills via shell injection
-- `lib/` — internal modules (config parser, classifier, git reader,
-  direction calculator, briefing renderer)
-- `agents/`, `hooks/` — empty, reserved for v0.2.0+
+- `scripts/{check,boot,init}.py` — Python entry points called from
+  skills via shell injection (`${CLAUDE_PLUGIN_ROOT}/scripts/...`)
+- `hooks/hooks.json` — `SessionStart` hook → `boot.py --hook`
+- `lib/` — config parser, classifier, git reader, direction calculator,
+  briefing renderer, runtime helpers
+- `agents/` — empty, reserved for v0.4.0+
 
 ## Config file
 

--- a/plugins/compass/hooks/.gitkeep
+++ b/plugins/compass/hooks/.gitkeep
@@ -1,2 +1,0 @@
-# Placeholder - hooks will be populated starting v0.1.0
-# See ../../ROADMAP.md

--- a/plugins/compass/hooks/hooks.json
+++ b/plugins/compass/hooks/hooks.json
@@ -1,0 +1,15 @@
+{
+  "hooks": {
+    "SessionStart": [
+      {
+        "matcher": "*",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "python3 ${CLAUDE_PLUGIN_ROOT}/scripts/boot.py --hook"
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/plugins/compass/lib/classify.py
+++ b/plugins/compass/lib/classify.py
@@ -1,4 +1,4 @@
-"""Classify files and commits against pillars + categories. Spec: docs/config.md §5-§6."""
+"""Classify files and commits. Spec: docs/config.md §5-§6."""
 from __future__ import annotations
 
 import fnmatch

--- a/plugins/compass/lib/config.py
+++ b/plugins/compass/lib/config.py
@@ -1,8 +1,6 @@
-"""Load, validate, default-fill .compass.toml. Spec: docs/config.md."""
+"""Load + validate + default-fill .compass.toml. Spec: docs/config.md."""
 from __future__ import annotations
-
-import re
-import tomllib
+import re, tomllib
 from pathlib import Path
 from typing import Any
 
@@ -33,6 +31,8 @@ DEFAULTS: dict[str, Any] = {
     "issues": {"enabled": False, "closed_window_days": 30},
     "ignore": [".git/**", "node_modules/**", "**/__pycache__/**",
                "*.lock", "dist/**", "build/**"],
+    "boot": {"enabled": True, "delegate_claude_md": False,
+             "escape_env": "COMPASS_SKIP_BOOT"},
     "evolve": {"enabled": False},
     "delegate_to": [],
 }
@@ -49,9 +49,7 @@ def load(path: Path) -> dict[str, Any]:
             raw = tomllib.load(f)
     except tomllib.TOMLDecodeError as e:
         raise ConfigError(f"{path}: TOML parse error: {e}") from e
-    cfg = _merge_defaults(raw)
-    _validate(cfg, path)
-    return cfg
+    cfg = _merge_defaults(raw); _validate(cfg, path); return cfg
 
 
 def _merge_defaults(raw: dict[str, Any]) -> dict[str, Any]:
@@ -62,6 +60,7 @@ def _merge_defaults(raw: dict[str, Any]) -> dict[str, Any]:
         "direction": _deep_merge(DEFAULTS["direction"], raw.get("direction", {})),
         "issues": {**DEFAULTS["issues"], **raw.get("issues", {})},
         "ignore": list(raw.get("ignore", DEFAULTS["ignore"])),
+        "boot": {**DEFAULTS["boot"], **raw.get("boot", {})},
         "evolve": {**DEFAULTS["evolve"], **raw.get("evolve", {})},
         "delegate_to": list(raw.get("delegate_to", [])),
         "categories": {},
@@ -80,10 +79,7 @@ def _merge_defaults(raw: dict[str, Any]) -> dict[str, Any]:
 def _deep_merge(base: dict[str, Any], override: dict[str, Any]) -> dict[str, Any]:
     out = dict(base)
     for k, v in override.items():
-        if isinstance(v, dict) and isinstance(out.get(k), dict):
-            out[k] = _deep_merge(out[k], v)
-        else:
-            out[k] = v
+        out[k] = _deep_merge(out[k], v) if isinstance(v, dict) and isinstance(out.get(k), dict) else v
     return out
 
 
@@ -141,10 +137,10 @@ def _validate(cfg: dict[str, Any], path: Path) -> None:
 
 
 def find_config(start: Path) -> Path | None:
-    """Walk up from start looking for .compass.toml. Returns path or None."""
+    """Walk up from start looking for .compass.toml."""
     cur = start.resolve()
     for parent in (cur, *cur.parents):
-        candidate = parent / ".compass.toml"
-        if candidate.exists():
-            return candidate
+        c = parent / ".compass.toml"
+        if c.exists():
+            return c
     return None

--- a/plugins/compass/lib/direction.py
+++ b/plugins/compass/lib/direction.py
@@ -100,15 +100,12 @@ def drift_signals(result: DirectionResult, commits: list[CommitHit],
 
 
 def next_smallest_step(result: DirectionResult, cfg: dict[str, Any]) -> str | None:
-    """Suggest a single concrete next action, smallest possible."""
     untouched = [pid for pid, n in result.pillars_touched.items() if n == 0]
     if untouched:
-        pid = untouched[0]
         for p in cfg["pillars"]:
-            if p["id"] == pid:
-                paths = p.get("paths") or []
-                hint = paths[0] if paths else "(no paths declared)"
-                return (f"Apri un commit su `{pid}`. Path più promettente: `{hint}`.")
+            if p["id"] == untouched[0]:
+                hint = (p.get("paths") or ["(no paths declared)"])[0]
+                return f"Apri un commit su `{untouched[0]}`. Path più promettente: `{hint}`."
     if result.core_share < 0.3 and result.window >= 5:
         return "Prossimo commit: tocca un file dentro un pilastro dichiarato."
     return None

--- a/plugins/compass/lib/git.py
+++ b/plugins/compass/lib/git.py
@@ -68,35 +68,16 @@ def recent_commits(repo: Path, window: int) -> list[dict[str, Any]]:
 
 
 def issues_summary(repo: Path, window_days: int) -> dict[str, int] | None:
-    """Use `gh issue list` to count open + recently closed issues.
-
-    Returns None if `gh` is missing or fails (caller falls back to neutral).
-    """
-    try:
-        open_out = subprocess.run(
-            ["gh", "issue", "list", "--state", "open", "--limit", "500",
-             "--json", "number"],
-            cwd=repo, check=True, capture_output=True, text=True,
-        )
-        closed_out = subprocess.run(
-            ["gh", "issue", "list", "--state", "closed", "--limit", "500",
-             "--search", f"closed:>={_iso_days_ago(window_days)}",
-             "--json", "number"],
-            cwd=repo, check=True, capture_output=True, text=True,
-        )
-    except (FileNotFoundError, subprocess.CalledProcessError):
-        return None
+    """`gh issue list` count of open + closed-in-window. None if `gh` missing/fails."""
     import json
-    try:
-        n_open = len(json.loads(open_out.stdout))
-        n_closed = len(json.loads(closed_out.stdout))
-    except (ValueError, TypeError):
-        return None
-    return {"open": n_open, "closed": n_closed}
-
-
-def _iso_days_ago(days: int) -> str:
-    """ISO date `days` ago, format YYYY-MM-DD."""
     from datetime import datetime, timedelta, timezone
-    d = datetime.now(timezone.utc) - timedelta(days=days)
-    return d.strftime("%Y-%m-%d")
+    since = (datetime.now(timezone.utc) - timedelta(days=window_days)).strftime("%Y-%m-%d")
+    base = ["gh", "issue", "list", "--limit", "500", "--json", "number"]
+    try:
+        op = subprocess.run([*base, "--state", "open"], cwd=repo, check=True,
+                            capture_output=True, text=True)
+        cl = subprocess.run([*base, "--state", "closed", "--search", f"closed:>={since}"],
+                            cwd=repo, check=True, capture_output=True, text=True)
+        return {"open": len(json.loads(op.stdout)), "closed": len(json.loads(cl.stdout))}
+    except (FileNotFoundError, subprocess.CalledProcessError, ValueError, TypeError):
+        return None

--- a/plugins/compass/lib/output.py
+++ b/plugins/compass/lib/output.py
@@ -1,4 +1,5 @@
-"""Render the /compass:check briefing markdown. Spec: docs/config.md §9."""
+"""Render briefings: full (/compass:check) and mini (/compass:boot, hook).
+Spec: docs/config.md §9."""
 from __future__ import annotations
 
 from datetime import date
@@ -8,69 +9,67 @@ from .direction import DirectionResult, drift_signals, next_smallest_step
 from .classify import CommitHit
 
 
+def _verdict(score: float, t: dict, with_emoji: bool = False) -> tuple[str, str]:
+    if score >= t["healthy"]:
+        return ("🟢", "rotta coerente") if with_emoji else ("", "rotta coerente")
+    if score < t["warning"]:
+        return ("🔴", "deriva evidente") if with_emoji else ("", "deriva evidente")
+    return ("🟡", "attenzione") if with_emoji else ("", "attenzione")
+
+
 def render_briefing(result: DirectionResult, commits: list[CommitHit],
                     cfg: dict[str, Any]) -> str:
     f = cfg["direction"]["formula"]
-    t = cfg["direction"]["thresholds"]
-
-    if result.score >= t["healthy"]:
-        verdict = "rotta coerente"
-    elif result.score < t["warning"]:
-        verdict = "deriva evidente"
-    else:
-        verdict = "attenzione"
-
-    issue_val = (f"{result.issue_factor:.2f}"
-                 if result.issues_enabled else "n/d (off)")
-
-    lines: list[str] = []
-    lines.append("# Compass — Direction check\n")
-    lines.append(
-        f"**Direction Index: {result.score:.0f} / 100** "
-        f"({verdict}) · window: {result.window} commits · "
-        f"generated: {date.today().isoformat()}\n"
-    )
-    lines.append("## Breakdown\n")
-    lines.append("| Componente       | Peso | Valore | Contributo |")
-    lines.append("|------------------|-----:|-------:|-----------:|")
-    lines.append(
-        f"| Core share       | {f['core_share']:.2f} | "
-        f"{result.core_share*100:5.0f}% | {result.core_contrib:>10.1f} |"
-    )
+    _, verdict = _verdict(result.score, cfg["direction"]["thresholds"])
+    issue_val = f"{result.issue_factor:.2f}" if result.issues_enabled else "n/d (off)"
     touched = sum(1 for n in result.pillars_touched.values() if n > 0)
-    lines.append(
-        f"| Pillar coverage  | {f['pillar_coverage']:.2f} | "
-        f"  {touched}/{result.pillars_total} | {result.pillar_contrib:>10.1f} |"
-    )
-    lines.append(
-        f"| Issue factor     | {f['issue_factor']:.2f} | "
-        f"{issue_val:>6} | {result.issue_contrib:>10.1f} |"
-    )
-    lines.append("")
-
-    lines.append("## Pilastri nel window")
+    L = [
+        "# Compass — Direction check\n",
+        f"**Direction Index: {result.score:.0f} / 100** ({verdict}) · "
+        f"window: {result.window} commits · generated: {date.today().isoformat()}\n",
+        "## Breakdown\n",
+        "| Componente       | Peso | Valore | Contributo |",
+        "|------------------|-----:|-------:|-----------:|",
+        f"| Core share       | {f['core_share']:.2f} | {result.core_share*100:5.0f}% | {result.core_contrib:>10.1f} |",
+        f"| Pillar coverage  | {f['pillar_coverage']:.2f} |   {touched}/{result.pillars_total} | {result.pillar_contrib:>10.1f} |",
+        f"| Issue factor     | {f['issue_factor']:.2f} | {issue_val:>6} | {result.issue_contrib:>10.1f} |",
+        "",
+        "## Pilastri nel window",
+    ]
     if not result.pillars_touched:
-        lines.append("- (nessun pilastro dichiarato)")
+        L.append("- (nessun pilastro dichiarato)")
     else:
         for p in cfg["pillars"]:
-            pid = p["id"]
-            n = result.pillars_touched.get(pid, 0)
-            mark = "[x]" if n > 0 else "[ ]"
-            label = f"`{pid}`" if n > 0 else f"**`{pid}`** ← 0 commit"
-            suffix = f" ({n} commit)" if n > 0 else ""
-            lines.append(f"- {mark} {label}{suffix}")
-    lines.append("")
-
-    signals = drift_signals(result, commits, cfg)
-    lines.append("## Drift signals (ranked)")
-    if not signals:
-        lines.append("- Nessun segnale di deriva sopra la soglia. ✓")
+            n = result.pillars_touched.get(p["id"], 0)
+            if n > 0:
+                L.append(f"- [x] `{p['id']}` ({n} commit)")
+            else:
+                L.append(f"- [ ] **`{p['id']}`** ← 0 commit")
+    L.append("")
+    sigs = drift_signals(result, commits, cfg)
+    L.append("## Drift signals (ranked)")
+    if sigs:
+        L.extend(f"{i}. {s}" for i, s in enumerate(sigs, 1))
     else:
-        for i, s in enumerate(signals, 1):
-            lines.append(f"{i}. {s}")
-    lines.append("")
-
+        L.append("- Nessun segnale di deriva sopra la soglia. ✓")
+    L.append("")
     step = next_smallest_step(result, cfg)
-    lines.append("## Next smallest step")
-    lines.append(step if step else "Nessuna correzione urgente. Continua.")
-    return "\n".join(lines).rstrip() + "\n"
+    L.append("## Next smallest step")
+    L.append(step if step else "Nessuna correzione urgente. Continua.")
+    return "\n".join(L).rstrip() + "\n"
+
+
+def render_brief_mini(result: DirectionResult, commits: list[CommitHit],
+                      cfg: dict[str, Any]) -> str:
+    """3-5 line direction brief for /compass:boot and SessionStart hook."""
+    emoji, verdict = _verdict(result.score, cfg["direction"]["thresholds"], with_emoji=True)
+    touched = sum(1 for n in result.pillars_touched.values() if n > 0)
+    lines = [f"{emoji} **Compass — DI {result.score:.0f}/100** ({verdict}) · "
+             f"pilastri {touched}/{result.pillars_total} · window {result.window} commit"]
+    sigs = drift_signals(result, commits, cfg)
+    if sigs:
+        lines.append(f"⚠ {sigs[0]}")
+    step = next_smallest_step(result, cfg)
+    if step:
+        lines.append(f"→ {step}")
+    return "\n".join(lines) + "\n"

--- a/plugins/compass/lib/runtime.py
+++ b/plugins/compass/lib/runtime.py
@@ -1,0 +1,52 @@
+"""Common entry-point helpers shared by check.py and boot.py."""
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+from typing import Any
+
+from . import config as cfgmod
+from . import git as gitmod
+from .classify import classify_commit
+
+
+def reconfigure_utf8() -> None:
+    for s in (sys.stdout, sys.stderr):
+        if hasattr(s, "reconfigure"):
+            try:
+                s.reconfigure(encoding="utf-8")
+            except (OSError, ValueError):
+                pass
+
+
+def _fail(msg: str, code: int, silent: bool) -> None:
+    if silent:
+        return None  # caller checks for None
+    print(f"ERROR: {msg}", file=sys.stderr); raise SystemExit(code)
+
+
+def load_repo_cfg(silent: bool = False) -> tuple[Path, dict[str, Any]] | None:
+    """Resolve repo + load .compass.toml. silent=True → None on errors;
+    silent=False → print + SystemExit."""
+    try:
+        repo = gitmod.repo_root(Path.cwd())
+    except gitmod.GitError as e:
+        return _fail(str(e), 2, silent)
+    cfg_path = cfgmod.find_config(repo)
+    if cfg_path is None:
+        return _fail("no .compass.toml found in repo. Run /compass:init first.", 3, silent)
+    try:
+        return repo, cfgmod.load(cfg_path)
+    except cfgmod.ConfigError as e:
+        return _fail(str(e), 4, silent)
+
+
+def collect_commits(repo: Path, cfg: dict[str, Any]) -> list:
+    raws = gitmod.recent_commits(repo, cfg["direction"]["window"])
+    return [classify_commit(c, cfg) for c in raws]
+
+
+def maybe_issues(repo: Path, cfg: dict[str, Any]) -> dict | None:
+    if not cfg["issues"]["enabled"]:
+        return None
+    return gitmod.issues_summary(repo, cfg["issues"]["closed_window_days"])

--- a/plugins/compass/scripts/boot.py
+++ b/plugins/compass/scripts/boot.py
@@ -1,0 +1,49 @@
+#!/usr/bin/env python3
+"""Entry point for /compass:boot and SessionStart hook (--hook flag).
+Outputs 3-5 line direction brief. Silent (exit 0) if not opted in
+(no .compass.toml), boot.enabled=false in hook context, or escape env set."""
+from __future__ import annotations
+
+import os
+import sys
+from pathlib import Path
+
+_PLUGIN_ROOT = Path(__file__).resolve().parent.parent
+if str(_PLUGIN_ROOT) not in sys.path:
+    sys.path.insert(0, str(_PLUGIN_ROOT))
+
+from lib.runtime import collect_commits, load_repo_cfg, maybe_issues, reconfigure_utf8  # noqa
+from lib.direction import compute  # noqa: E402
+from lib.output import render_brief_mini  # noqa: E402
+
+
+def _claude_md_hint(cfg: dict, repo: Path) -> str | None:
+    if cfg["boot"].get("delegate_claude_md") and (repo / "CLAUDE.md").exists():
+        return "💡 `claude-md-management` installato? Considera `/claude-md:audit`."
+    return None
+
+
+def main(argv: list[str]) -> int:
+    reconfigure_utf8()
+    is_hook = "--hook" in argv
+    loaded = load_repo_cfg(silent=is_hook)
+    if loaded is None:
+        return 0
+    repo, cfg = loaded
+    boot = cfg["boot"]
+    if is_hook:
+        if not boot.get("enabled", True):
+            return 0
+        if os.environ.get(boot.get("escape_env", "COMPASS_SKIP_BOOT")):
+            return 0
+    commits = collect_commits(repo, cfg)
+    result = compute(commits, cfg, maybe_issues(repo, cfg))
+    sys.stdout.write(render_brief_mini(result, commits, cfg))
+    hint = _claude_md_hint(cfg, repo)
+    if hint:
+        sys.stdout.write(hint + "\n")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main(sys.argv[1:]))

--- a/plugins/compass/scripts/check.py
+++ b/plugins/compass/scripts/check.py
@@ -1,71 +1,30 @@
 #!/usr/bin/env python3
-"""Entry point for /compass:check. Reads .compass.toml, computes Direction Index,
-prints markdown briefing on stdout. Exits non-zero on config errors."""
+"""Entry point for /compass:check. Reads .compass.toml, computes Direction
+Index, prints markdown briefing on stdout."""
 from __future__ import annotations
 
 import sys
 from pathlib import Path
 
-# Force UTF-8 on stdout/stderr (Windows defaults to cp1252).
-for _stream in (sys.stdout, sys.stderr):
-    if hasattr(_stream, "reconfigure"):
-        try:
-            _stream.reconfigure(encoding="utf-8")
-        except (OSError, ValueError):
-            pass
-
-# Allow running from anywhere: add plugin root to sys.path so `lib.*` resolves.
-_HERE = Path(__file__).resolve().parent
-_PLUGIN_ROOT = _HERE.parent
+_PLUGIN_ROOT = Path(__file__).resolve().parent.parent
 if str(_PLUGIN_ROOT) not in sys.path:
     sys.path.insert(0, str(_PLUGIN_ROOT))
 
-from lib import config as cfgmod  # noqa: E402
-from lib import git as gitmod     # noqa: E402
-from lib.classify import classify_commit  # noqa: E402
+from lib.runtime import collect_commits, load_repo_cfg, maybe_issues, reconfigure_utf8  # noqa
 from lib.direction import compute  # noqa: E402
 from lib.output import render_briefing  # noqa: E402
 
 
-def main(argv: list[str]) -> int:
-    cwd = Path.cwd()
-    try:
-        repo = gitmod.repo_root(cwd)
-    except gitmod.GitError as e:
-        print(f"ERROR: {e}", file=sys.stderr)
-        return 2
-
-    cfg_path = cfgmod.find_config(repo)
-    if cfg_path is None:
-        print(
-            "ERROR: no .compass.toml found in repo. Run /compass:init first.",
-            file=sys.stderr,
-        )
-        return 3
-
-    try:
-        cfg = cfgmod.load(cfg_path)
-    except cfgmod.ConfigError as e:
-        print(f"ERROR: {e}", file=sys.stderr)
-        return 4
-
-    window = cfg["direction"]["window"]
-    try:
-        commits_raw = gitmod.recent_commits(repo, window)
-    except gitmod.GitError as e:
-        print(f"ERROR: {e}", file=sys.stderr)
-        return 5
-
-    commits = [classify_commit(c, cfg) for c in commits_raw]
-
-    issues = None
-    if cfg["issues"]["enabled"]:
-        issues = gitmod.issues_summary(repo, cfg["issues"]["closed_window_days"])
-
-    result = compute(commits, cfg, issues)
+def main() -> int:
+    reconfigure_utf8()
+    loaded = load_repo_cfg(silent=False)
+    assert loaded is not None  # silent=False raises SystemExit on failure
+    repo, cfg = loaded
+    commits = collect_commits(repo, cfg)
+    result = compute(commits, cfg, maybe_issues(repo, cfg))
     sys.stdout.write(render_briefing(result, commits, cfg))
     return 0
 
 
 if __name__ == "__main__":
-    raise SystemExit(main(sys.argv[1:]))
+    raise SystemExit(main())

--- a/plugins/compass/scripts/init.py
+++ b/plugins/compass/scripts/init.py
@@ -1,13 +1,7 @@
 #!/usr/bin/env python3
-"""Helpers for /compass:init. Two subcommands:
-  inspect              Print JSON summary of the current repo (top-dirs,
-                       README presence, detected language hints, project
-                       type guess, suggested pillars).
-  write <toml-file>    Validate the proposed TOML config and write it to
-                       .compass.toml at the repo root. Emits OK/ERROR.
-
-The interactive Q&A is driven by Claude reading inspect output and
-proposing pillars to the user; this script is a pure utility."""
+"""Helpers for /compass:init. Subcommands: inspect | write <toml-file>.
+The interactive Q&A is driven by Claude reading inspect output;
+this script is a pure utility."""
 from __future__ import annotations
 
 import json
@@ -34,34 +28,23 @@ PROJECT_TYPE_BY_SIGNALS: list[tuple[str, list[str]]] = [
     ("docs",     ["mkdocs.yml", "docusaurus.config.js", "_config.yml", "book.toml"]),
 ]
 
-# (id, name, paths) tuples per project type. Pillars whose paths don't match
-# anything in repo are dropped at suggestion time.
+# Pillars whose paths don't match anything in repo are dropped at suggest time.
 DEFAULT_PILLAR_TEMPLATES: dict[str, list[tuple[str, str, list[str]]]] = {
-    "game-dev": [
-        ("gameplay-core", "Gameplay & feel", ["src/game/**", "scenes/**", "assets/**"]),
-        ("balance-data", "Balance & data", ["data/**", "balance/**"]),
-        ("tactics-readability", "Lettura tattica UI", ["ui/**", "hud/**"]),
-    ],
-    "web-saas": [
-        ("core-funnel", "Core funnel", ["app/(main)/**", "src/pages/**"]),
-        ("perf-reliability", "Performance & reliability", ["src/lib/**", "src/server/**"]),
-        ("onboarding", "Onboarding", ["src/onboarding/**", "app/(onboarding)/**"]),
-    ],
-    "library": [
-        ("api-stability", "API stability", ["src/**", "lib/**"]),
-        ("examples", "Examples & docs", ["examples/**", "docs/**"]),
-        ("compat-perf", "Compatibility & perf", ["benches/**", "tests/perf/**"]),
-    ],
-    "research": [
-        ("experiments", "Experiments", ["experiments/**", "notebooks/**"]),
-        ("writeup", "Writeup & figures", ["paper/**", "figures/**"]),
-        ("reproducibility", "Reproducibility", ["env/**", "scripts/**"]),
-    ],
-    "docs": [
-        ("content", "Content", ["docs/**", "src/**"]),
-        ("navigation", "Navigation & IA", ["mkdocs.yml", "_config.yml", "sidebars.*"]),
-    ],
-    "other": [("core", "Core", ["src/**"])],
+    "game-dev": [("gameplay-core", "Gameplay & feel", ["src/game/**", "scenes/**", "assets/**"]),
+                 ("balance-data", "Balance & data", ["data/**", "balance/**"]),
+                 ("tactics-readability", "Lettura tattica UI", ["ui/**", "hud/**"])],
+    "web-saas": [("core-funnel", "Core funnel", ["app/(main)/**", "src/pages/**"]),
+                 ("perf-reliability", "Performance & reliability", ["src/lib/**", "src/server/**"]),
+                 ("onboarding", "Onboarding", ["src/onboarding/**", "app/(onboarding)/**"])],
+    "library":  [("api-stability", "API stability", ["src/**", "lib/**"]),
+                 ("examples", "Examples & docs", ["examples/**", "docs/**"]),
+                 ("compat-perf", "Compatibility & perf", ["benches/**", "tests/perf/**"])],
+    "research": [("experiments", "Experiments", ["experiments/**", "notebooks/**"]),
+                 ("writeup", "Writeup & figures", ["paper/**", "figures/**"]),
+                 ("reproducibility", "Reproducibility", ["env/**", "scripts/**"])],
+    "docs":     [("content", "Content", ["docs/**", "src/**"]),
+                 ("navigation", "Navigation & IA", ["mkdocs.yml", "_config.yml", "sidebars.*"])],
+    "other":    [("core", "Core", ["src/**"])],
 }
 
 
@@ -108,11 +91,8 @@ def _suggest_pillars(repo: Path, ptype: str) -> list[dict]:
 
 
 def _has_match(repo: Path, pattern: str) -> bool:
-    """Cheap check: does any path in repo match this glob? Uses pathlib.glob."""
     try:
-        # pathlib doesn't support ** without recursive flag; substitute.
-        pat = pattern.replace("**", "*")
-        return any(True for _ in repo.glob(pat))
+        return any(True for _ in repo.glob(pattern.replace("**", "*")))
     except (OSError, ValueError):
         return False
 
@@ -122,19 +102,15 @@ def cmd_inspect(repo_arg: str | None) -> int:
     try:
         repo = gitmod.repo_root(cwd)
     except gitmod.GitError as e:
-        print(json.dumps({"error": str(e)}))
-        return 2
+        print(json.dumps({"error": str(e)})); return 2
     ptype = _detect_project_type(repo)
-    info = {
-        "repo_root": str(repo),
-        "name": repo.name,
-        "project_type": ptype,
+    print(json.dumps({
+        "repo_root": str(repo), "name": repo.name, "project_type": ptype,
         "top_dirs": _top_dirs(repo),
         "has_readme": any((repo / n).exists() for n in ("README.md", "readme.md", "README.rst")),
         "has_existing_config": (repo / ".compass.toml").exists(),
         "suggested_pillars": _suggest_pillars(repo, ptype),
-    }
-    print(json.dumps(info, indent=2, ensure_ascii=False))
+    }, indent=2, ensure_ascii=False))
     return 0
 
 
@@ -145,14 +121,12 @@ def cmd_write(toml_file: str) -> int:
     try:
         with src.open("rb") as f:
             tomllib.load(f)
+        cfg = cfgmod.load(src)
+        repo = gitmod.repo_root(Path.cwd())
     except tomllib.TOMLDecodeError as e:
         print(f"ERROR: invalid TOML: {e}", file=sys.stderr); return 3
-    try:
-        cfg = cfgmod.load(src)
     except cfgmod.ConfigError as e:
         print(f"ERROR: schema validation failed: {e}", file=sys.stderr); return 4
-    try:
-        repo = gitmod.repo_root(Path.cwd())
     except gitmod.GitError as e:
         print(f"ERROR: {e}", file=sys.stderr); return 5
     dst = repo / ".compass.toml"
@@ -165,14 +139,11 @@ def cmd_write(toml_file: str) -> int:
 
 
 def main(argv: list[str]) -> int:
-    if not argv:
-        print("usage: init.py inspect [REPO] | write TOMLFILE", file=sys.stderr); return 1
-    sub = argv[0]
-    if sub == "inspect":
+    if argv and argv[0] == "inspect":
         return cmd_inspect(argv[1] if len(argv) > 1 else None)
-    if sub == "write" and len(argv) >= 2:
+    if len(argv) >= 2 and argv[0] == "write":
         return cmd_write(argv[1])
-    print(f"ERROR: unknown or malformed subcommand {sub!r}", file=sys.stderr)
+    print("usage: init.py inspect [REPO] | write TOMLFILE", file=sys.stderr)
     return 1
 
 

--- a/plugins/compass/skills/compass-boot/SKILL.md
+++ b/plugins/compass/skills/compass-boot/SKILL.md
@@ -1,0 +1,30 @@
+---
+name: boot
+description: Direction-aware kickoff for the start of a session. Prints a 3-5 line mini-brief (Direction Index + top drift + next-smallest-step) to orient the user fast. Use when the user says "boot", "kickoff", "compass boot", "start the session", "where do I start today".
+allowed-tools: Bash
+---
+
+# /compass:boot — kickoff direzionale
+
+Mini version of `/compass:check`: same data, three lines instead of
+forty. Useful at session start to orient without burning context.
+
+```!
+python3 "${CLAUDE_PLUGIN_ROOT}/scripts/boot.py"
+```
+
+Present output verbatim. If the script prints nothing (silent exit), the
+project is not Compass-opted-in (no `.compass.toml`) — suggest
+`/compass:init` and stop. Don't add interpretation.
+
+## Escape hatch
+
+If user says "skip boot" or sets `COMPASS_SKIP_BOOT=1`, the
+`SessionStart` hook stays silent. `/compass:boot` invoked directly
+ignores the env var (manual call = explicit intent).
+
+## When to delegate
+
+If `boot.delegate_claude_md = true` in `.compass.toml` and the user has
+`claude-md-management` installed, the brief includes a one-line hint
+suggesting `/claude-md:audit`. Don't auto-run it; user decides.


### PR DESCRIPTION
## Summary

Ship v0.2.0 \"Boot\" per `ROADMAP.md`.

- `/compass:boot` — direction-aware kickoff. Mini-brief 3-5 righe (verdict emoji + DI + pillar coverage + top drift + next step).
- **SessionStart hook** (`hooks/hooks.json`) — inietta automaticamente lo stesso brief all'apertura sessione. Silent (exit 0) se progetto non opt-in, `boot.enabled=false`, o `COMPASS_SKIP_BOOT=1`.
- **claude-md-management delegation** — hint a `/claude-md:audit` nel brief se `boot.delegate_claude_md=true` + `CLAUDE.md` esiste. Mai auto-invocato.
- **Escape hatch** — env var `COMPASS_SKIP_BOOT` (configurabile via `boot.escape_env`).
- Schema `.compass.toml`: nuova sezione `[boot]`.
- `lib/runtime.py` introdotto per DRY check/boot (load_repo_cfg, reconfigure_utf8, collect_commits, maybe_issues).
- Versioni bumped a 0.2.0 in entrambi i manifest.

## Architettura

\`\`\`
plugins/compass/
├── hooks/hooks.json              ← SessionStart → boot.py --hook
├── scripts/{check,boot,init}.py
├── skills/compass-{init,check,boot,lens}/SKILL.md
└── lib/{config,classify,git,direction,output,runtime,__init__}.py
\`\`\`

Budget LOC plugin: **800 / 800** esatto. Zero margine, ma rigorosamente sotto. Stdlib only.

## Test plan

Self-test su \`compass-marketplace\` (DI 88/100, 3 pillar tutti toccati):

- [x] \`/compass:check\` produce briefing markdown 22 righe (full)
- [x] \`/compass:boot\` produce mini-brief 2-3 righe + claude-md hint
- [x] \`SessionStart\` hook silent con \`COMPASS_SKIP_BOOT=1\` (exit 0)
- [x] \`SessionStart\` hook silent senza \`.compass.toml\` (exit 0)
- [x] Hook silent quando \`boot.enabled = false\`
- [x] Hook mai noisy: config malformata in hook context → silent
- [x] \`/compass:boot\` diretto ignora escape_env (manual = intent)

ROADMAP v0.2.0: 4/4 checkbox spuntati.

## Files changed

1 commit: \`7c689ef\` — 17 file, +326 −239 LOC.

🤖 Generated with [Claude Code](https://claude.com/claude-code)