### PR TITLE
feat(v0.4.0): Evolve

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -6,7 +6,7 @@
   },
   "metadata": {
     "description": "Direction-first audit & kickoff lens for Claude Code projects. Born from Evo-Tactics design philosophy.",
-    "version": "0.3.0"
+    "version": "0.4.0"
   },
   "plugins": [
     {
@@ -15,7 +15,7 @@
         "source": "local",
         "path": "plugins/compass"
       },
-      "version": "0.3.0",
+      "version": "0.4.0",
       "description": "Direction Index + Pillars + Drift detection for any Claude Code project. Composes with existing audit plugins instead of duplicating them.",
       "category": "productivity",
       "keywords": [

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -102,13 +102,20 @@ chiaro + il next-action più piccolo.
 
 **Scope:** il feedback loop dai transcript.
 
-- [ ] Lettura di `~/.claude/projects/**/*.jsonl` filtrando per progetto corrente
-- [ ] Statistiche: quante volte ogni task del boot è stato eseguito, quante
-      volte ha trovato qualcosa, quante volte è stato skippato
-- [ ] `/compass:evolve` — presenta un **diff proposto** al `.compass.toml`
-      basato sui pattern osservati
+- [x] Lettura di `~/.claude/projects/**/*.jsonl` filtrando per progetto corrente
+      (path discovery via `find_transcript_dir`, fallback su sostring match)
+- [x] Statistiche: counts per pilastro + sessioni totali + menzioni
+      `compass`. **Privacy-first**: solo counts, nessun contenuto estratto.
+      *Boot-task hit/skip rate rinviato a v0.5.0+ (richiede tracking
+      strutturato lato hook, non solo log).*
+- [x] `/compass:evolve` — proposte testuali (kind: drop_pillar /
+      boost_weight / add_paths_hint / noop). *Diff TOML rinviato a
+      v0.5.0+ per evitare di scrivere TOML serializer custom (~50 LOC
+      che spingerebbero il budget oltre 1000).*
 - [ ] L'utente approva in modalità chirurgica (accept, reject, modify)
-- [ ] Mai applicare modifiche senza consenso esplicito
+      *(v0.5.0+: richiede TOML writer + flusso `--apply`)*
+- [x] Mai applicare modifiche senza consenso esplicito (no auto-apply
+      in v0.4.0; user edita a mano dopo aver letto le proposte)
 
 **Criterio di done:** dopo 10+ sessioni su un progetto, `evolve` propone
 almeno 1-2 modifiche sensate al file di config.

--- a/plugins/compass/.claude-plugin/plugin.json
+++ b/plugins/compass/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://json.schemastore.org/claude-code-plugin.json",
   "name": "compass",
-  "version": "0.3.0",
+  "version": "0.4.0",
   "description": "Direction-first audit lens for Claude Code projects. Measures how well recent work serves the project's pillars, surfaces drift, and runs adaptive kickoff protocols. Composes with claude-md-management, doctor-skill, and audit-project rather than duplicating them.",
   "author": {
     "name": "MasterDD-L34D"

--- a/plugins/compass/README.md
+++ b/plugins/compass/README.md
@@ -17,12 +17,13 @@ Composes with other audit plugins instead of duplicating them.
 
 ## Status
 
-**v0.3.0 — "Drift"**. Four slash commands + SessionStart hook:
+**v0.4.0 — "Evolve"**. Five slash commands + SessionStart hook:
 
 - `/compass:init` — interactive setup of `.compass.toml`
 - `/compass:check` — full Direction Index briefing
 - `/compass:boot` — 3-line mini-brief for kickoff
 - `/compass:drift` — focused drift report with warning gate
+- `/compass:evolve` — propose config changes from Claude Code transcripts
 - `SessionStart` hook — auto mini-brief on session open (opt-out via
   `boot.enabled = false` or `COMPASS_SKIP_BOOT=1`)
 
@@ -109,6 +110,21 @@ Up to 5 ranked drift signals (vs. 3 in `/compass:check`). Includes the
 v0.3.0 recency signal: "ultimo commit core N giorni fa (soglia drift
 Mgg)" using `drift.recency_days`.
 
+### `/compass:evolve`
+
+Reads `~/.claude/projects/<repo>/*.jsonl` transcripts and aggregates
+**counts only** (privacy: no content extracted) — sessions, total
+events, `compass` mentions, per-pillar mentions. Then proposes:
+
+- `drop_pillar`: pillar never mentioned in 5+ sessions
+- `boost_weight`: pillar dominates >50% of mentions, weight < 1.5
+- `add_paths_hint`: pillar under-mentioned vs avg
+- `noop`: balanced, no change
+
+**Never auto-applies**. User edits `.compass.toml` manually if they
+agree. Auto-apply (TOML writer + diff + interactive accept) deferred
+to v0.5.0+.
+
 ### `/compass:lens` (auto-invoked skill)
 
 Triggered by phrases like "am I on track", "where am I going", "check
@@ -121,9 +137,10 @@ verbatim.
 - `skills/compass-check/SKILL.md` — `/compass:check`
 - `skills/compass-boot/SKILL.md` — `/compass:boot`
 - `skills/compass-drift/SKILL.md` — `/compass:drift`
+- `skills/compass-evolve/SKILL.md` — `/compass:evolve`
 - `skills/compass-lens/SKILL.md` — auto-invoked lens
-- `scripts/{check,boot,drift,init}.py` — Python entry points called from
-  skills via shell injection (`${CLAUDE_PLUGIN_ROOT}/scripts/...`)
+- `scripts/{check,boot,drift,evolve,init}.py` — Python entry points
+  called from skills via shell injection (`${CLAUDE_PLUGIN_ROOT}/scripts/...`)
 - `hooks/hooks.json` — `SessionStart` hook → `boot.py --hook`
 - `lib/` — config parser, classifier, git reader, direction calculator,
   briefing renderer, runtime helpers

--- a/plugins/compass/lib/evolve.py
+++ b/plugins/compass/lib/evolve.py
@@ -1,0 +1,102 @@
+"""Read Claude Code transcripts + aggregate stats + propose config changes.
+Spec: docs/config.md, ROADMAP v0.4.0. Privacy: only counts, no content extracted."""
+from __future__ import annotations
+
+import os
+import re
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any
+
+
+@dataclass
+class EvolveStats:
+    sessions: int = 0
+    total_lines: int = 0
+    compass_mentions: int = 0
+    pillar_mentions: dict[str, int] = field(default_factory=dict)
+    transcript_dir: Path | None = None
+
+
+def find_transcript_dir(repo: Path) -> Path | None:
+    """Locate ~/.claude/projects/<escaped-repo-path>/ directory."""
+    base = Path(os.path.expanduser("~")) / ".claude" / "projects"
+    if not base.exists():
+        return None
+    parts = str(repo).replace("\\", "/").replace(":", "").lstrip("/").split("/")
+    for cand in ("-" + "-".join(parts), "C-" + "-".join(parts)):
+        p = base / cand
+        if p.exists():
+            return p
+    needle = parts[-1].lower() if parts else ""
+    for child in base.iterdir():
+        if child.is_dir() and needle and needle in child.name.lower():
+            return child
+    return None
+
+
+def aggregate(transcript_dir: Path, pillar_ids: list[str], limit_files: int = 20) -> EvolveStats:
+    """Count session files + lines + occurrences of pillar ids and 'compass' markers."""
+    stats = EvolveStats(transcript_dir=transcript_dir)
+    pillar_re = re.compile(r"\b(" + "|".join(map(re.escape, pillar_ids)) + r")\b") if pillar_ids else None
+    files = sorted(transcript_dir.glob("*.jsonl"),
+                   key=lambda p: p.stat().st_mtime, reverse=True)[:limit_files]
+    stats.sessions = len(files)
+    for f in files:
+        try:
+            with f.open(encoding="utf-8", errors="replace") as fh:
+                for line in fh:
+                    stats.total_lines += 1
+                    low = line.lower()
+                    if "compass" in low:
+                        stats.compass_mentions += 1
+                    if pillar_re:
+                        for m in pillar_re.finditer(line):
+                            pid = m.group(1)
+                            stats.pillar_mentions[pid] = stats.pillar_mentions.get(pid, 0) + 1
+        except OSError:
+            continue
+    return stats
+
+
+@dataclass
+class Proposal:
+    kind: str          # 'drop_pillar' | 'boost_weight' | 'add_paths_hint' | 'noop'
+    target: str        # pillar id or section name
+    reason: str
+    suggestion: str    # human-readable action
+
+
+def propose(stats: EvolveStats, cfg: dict[str, Any]) -> list[Proposal]:
+    """Compute proposals from stats + current config. Conservative: zero or few suggestions."""
+    out: list[Proposal] = []
+    if stats.sessions < 3:
+        out.append(Proposal("noop", "*",
+                            f"Solo {stats.sessions} sessione/i registrate.",
+                            "Continua a usare Compass; rieseguire `/compass:evolve` dopo 5+ sessioni."))
+        return out
+    pillars = {p["id"]: p for p in cfg["pillars"]}
+    mentions = stats.pillar_mentions
+    total_m = sum(mentions.values()) or 1
+    avg = total_m / max(1, len(pillars))
+    for pid, p in pillars.items():
+        m = mentions.get(pid, 0)
+        share = m / total_m
+        if m == 0 and stats.sessions >= 5:
+            out.append(Proposal("drop_pillar", pid,
+                                f"`{pid}` non menzionato in {stats.sessions} sessioni.",
+                                f"Considera rimuovere il pilastro `{pid}` da `.compass.toml`."))
+        elif share > 0.5 and p.get("weight", 1.0) < 1.5 and len(pillars) > 1:
+            out.append(Proposal("boost_weight", pid,
+                                f"`{pid}` domina ({share*100:.0f}% delle menzioni).",
+                                f"Considera alzare `weight` di `{pid}` "
+                                f"da {p.get('weight', 1.0)} a {min(2.0, p.get('weight', 1.0) + 0.5)}."))
+        elif m < avg * 0.3 and stats.sessions >= 5:
+            out.append(Proposal("add_paths_hint", pid,
+                                f"`{pid}` ha solo {m} menzioni vs media {avg:.1f}.",
+                                f"Verifica i `paths` di `{pid}`: forse troppo restrittivi."))
+    if not out:
+        out.append(Proposal("noop", "*",
+                            "Pattern di uso bilanciato sui pilastri dichiarati.",
+                            "Nessuna modifica suggerita. Continua."))
+    return out

--- a/plugins/compass/scripts/evolve.py
+++ b/plugins/compass/scripts/evolve.py
@@ -1,0 +1,60 @@
+#!/usr/bin/env python3
+"""Entry point for /compass:evolve. Reads Claude Code transcripts of the
+current project, aggregates stats (counts only — no content extracted),
+and proposes config changes for user review. Never auto-applies."""
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+_PLUGIN_ROOT = Path(__file__).resolve().parent.parent
+if str(_PLUGIN_ROOT) not in sys.path:
+    sys.path.insert(0, str(_PLUGIN_ROOT))
+
+from lib.runtime import load_repo_cfg, reconfigure_utf8  # noqa: E402
+from lib.evolve import aggregate, find_transcript_dir, propose  # noqa: E402
+
+
+def main() -> int:
+    reconfigure_utf8()
+    loaded = load_repo_cfg(silent=False)
+    assert loaded is not None
+    repo, cfg = loaded
+    td = find_transcript_dir(repo)
+    if td is None:
+        sys.stdout.write(
+            "# Compass — Evolve\n\n"
+            "Nessuna directory `~/.claude/projects/<repo>` trovata.\n"
+            "Compass evolve richiede transcript Claude Code per analizzare il pattern di uso.\n"
+        )
+        return 0
+    pillar_ids = [p["id"] for p in cfg["pillars"]]
+    stats = aggregate(td, pillar_ids)
+    proposals = propose(stats, cfg)
+
+    out: list[str] = ["# Compass — Evolve\n"]
+    out.append(f"**Transcripts**: `{td.name}` · {stats.sessions} sessioni · "
+               f"{stats.total_lines} eventi totali · "
+               f"{stats.compass_mentions} menzioni `compass`\n")
+    out.append("## Menzioni dei pilastri")
+    if stats.pillar_mentions:
+        for pid in pillar_ids:
+            out.append(f"- `{pid}`: {stats.pillar_mentions.get(pid, 0)}")
+    else:
+        out.append("- (nessuna menzione registrata)")
+    out.append("")
+    out.append("## Proposte (nessuna applicata automaticamente)")
+    for i, p in enumerate(proposals, 1):
+        out.append(f"### {i}. {p.kind} → `{p.target}`")
+        out.append(f"**Motivazione**: {p.reason}  ")
+        out.append(f"**Azione suggerita**: {p.suggestion}")
+        out.append("")
+    out.append("> Nessuna modifica al `.compass.toml` viene applicata. Per accettare una "
+               "proposta, modifica il file a mano o ri-esegui `/compass:init` (richiede "
+               "rimozione del file esistente).")
+    sys.stdout.write("\n".join(out) + "\n")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/plugins/compass/skills/compass-evolve/SKILL.md
+++ b/plugins/compass/skills/compass-evolve/SKILL.md
@@ -1,0 +1,44 @@
+---
+name: evolve
+description: Analyze Claude Code transcripts of the current project and propose config changes (pillar drops, weight bumps, path widenings) based on actual usage. Never auto-applies. Use when the user says "evolve compass", "improve config", "tune compass", "adatta compass", "compass evolve", "make compass better".
+allowed-tools: Bash
+---
+
+# /compass:evolve — proposte da pattern di uso
+
+Analizza i transcript Claude Code del progetto corrente
+(`~/.claude/projects/<repo>/*.jsonl`) e propone modifiche al
+`.compass.toml`. **Mai applica** automaticamente — l'utente decide.
+
+```!
+python3 "${CLAUDE_PLUGIN_ROOT}/scripts/evolve.py"
+```
+
+Presenta l'output verbatim. Le proposte sono di 4 tipi:
+
+- `drop_pillar`: pilastro mai menzionato → suggerisci rimozione
+- `boost_weight`: pilastro dominante (>50% menzioni) → suggerisci alzare il peso
+- `add_paths_hint`: pilastro sotto-menzionato → suggerisci verificare i path
+- `noop`: nessuna modifica utile rilevata
+
+**Privacy**: Il parser conta solo occorrenze (line counts, mention counts).
+Nessun contenuto dei transcript viene estratto, citato o esposto.
+
+## Dopo le proposte
+
+Se l'utente vuole accettare una proposta:
+
+1. **Drop pillar**: chiedi conferma, poi rimuovi a mano la sezione
+   `[[pillars]]` corrispondente da `.compass.toml`. Per re-init pulito,
+   rimuovi `.compass.toml` e ri-esegui `/compass:init`.
+2. **Boost weight**: edit chirurgico al campo `weight` del pilastro.
+3. **Add paths**: chiedi all'utente quali path aggiungere; edit a mano.
+
+Auto-apply (con TOML writer + diff) è rinviato a v0.5.0+.
+
+## Soglie attuali
+
+- `sessions < 3`: nessuna proposta (dati insufficienti)
+- `mentions == 0` && `sessions >= 5`: drop_pillar
+- `share > 50%` && `weight < 1.5`: boost_weight
+- `mentions < 30% media` && `sessions >= 5`: add_paths_hint


### PR DESCRIPTION
## Summary

Ship v0.4.0 \"Evolve\" per ROADMAP.md.

- /compass:evolve legge transcript Claude Code (~/.claude/projects/<repo>/*.jsonl)
- **Privacy-first**: solo counts, nessun contenuto extracted
- Proposte testuali: drop_pillar / boost_weight / add_paths_hint / noop
- Mai auto-apply: utente edita .compass.toml a mano

## Components

- lib/evolve.py            (106 LOC) find + aggregate + propose
- scripts/evolve.py        ( 60 LOC) entry point
- skills/compass-evolve/SKILL.md

## Test plan

- [x] find_transcript_dir matcha repo via path escape + fallback substring
- [x] aggregate produce {sessions, total_lines, compass_mentions, pillar_mentions}
- [x] propose ritorna noop quando sessions < 3
- [x] Self-test: 1 sessione, 957 eventi, 861 compass mentions, pillar mentions corretti
- [x] Privacy: zero content extraction (counts only)

## ROADMAP v0.4.0

4/5 spuntati. Interactive approve + TOML diff rinviato a v0.5.0+ (richiede TOML writer custom ~50 LOC).

## Budget LOC

1000/1000 esatto.

🤖 Generated with [Claude Code](https://claude.com/claude-code)