### PR TITLE
fix(v0.4.1): UTF-8 decoding for git subprocess on Windows

### DIFF
--- a/plugins/compass/lib/git.py
+++ b/plugins/compass/lib/git.py
@@ -13,7 +13,8 @@ class GitError(RuntimeError):
 def _run(args: list[str], cwd: Path) -> str:
     try:
         out = subprocess.run(
-            ["git", *args], cwd=cwd, check=True, capture_output=True, text=True
+            ["git", *args], cwd=cwd, check=True, capture_output=True,
+            text=True, encoding="utf-8", errors="replace",
         )
     except FileNotFoundError as e:
         raise GitError("git CLI not found in PATH") from e
@@ -73,11 +74,11 @@ def issues_summary(repo: Path, window_days: int) -> dict[str, int] | None:
     from datetime import datetime, timedelta, timezone
     since = (datetime.now(timezone.utc) - timedelta(days=window_days)).strftime("%Y-%m-%d")
     base = ["gh", "issue", "list", "--limit", "500", "--json", "number"]
+    kw = dict(cwd=repo, check=True, capture_output=True, text=True,
+              encoding="utf-8", errors="replace")
     try:
-        op = subprocess.run([*base, "--state", "open"], cwd=repo, check=True,
-                            capture_output=True, text=True)
-        cl = subprocess.run([*base, "--state", "closed", "--search", f"closed:>={since}"],
-                            cwd=repo, check=True, capture_output=True, text=True)
+        op = subprocess.run([*base, "--state", "open"], **kw)
+        cl = subprocess.run([*base, "--state", "closed", "--search", f"closed:>={since}"], **kw)
         return {"open": len(json.loads(op.stdout)), "closed": len(json.loads(cl.stdout))}
     except (FileNotFoundError, subprocess.CalledProcessError, ValueError, TypeError):
         return None


### PR DESCRIPTION
## Summary

Bug discovered while dogfooding Compass on \`evo-swarm\` repo (sibling of compass-marketplace).

\`git log\` con commit italiani/emoji esplodeva con \`UnicodeDecodeError: cp1252 cannot decode 0x8f\`. Default \`text=True\` su Windows usa cp1252 che fallisce.

**Fix**: forced \`encoding='utf-8' errors='replace'\` su tutte le \`subprocess.run\` in \`lib/git.py\` (\`_run\` + \`issues_summary\`).

## Test plan

- [x] Pre-fix: \`/compass:check\` da evo-swarm → crash UnicodeDecodeError
- [x] Post-fix: \`/compass:check\` → DI 76/100, 5/6 pillars touched
- [x] \`/compass:drift\` ranked signals OK
- [x] \`/compass:boot\` mini-brief OK
- [x] Validation empirica: drift signal \`temperamenti-reali non toccato\` combacia con baseline SWARM-PILLARS.md 🔴 status

🤖 Generated with [Claude Code](https://claude.com/claude-code)