### PR TITLE
fix: whitelist (docs, core) mismatch for pillar-tagged narrative docs (closes #9)

### DIFF
--- a/plugins/compass/lib/classify.py
+++ b/plugins/compass/lib/classify.py
@@ -105,5 +105,15 @@ def classify_commit(commit: dict[str, Any], cfg: dict[str, Any]) -> CommitHit:
     ch.dominant_category = max(weights.items(), key=lambda kv: kv[1])[0]
     msg_cat = _category_from_message(ch.message, cfg)
     if msg_cat is not None and msg_cat != ch.dominant_category:
-        ch.verified = False
+        # docs + core is a legitimate co-occurrence when the mismatch comes entirely
+        # from pillar-tagged .md files: those are both docs (form) and core (semantic
+        # mapping) by design. Flag only genuine category conflicts.
+        pillar_md_only = (
+            msg_cat == "docs"
+            and ch.dominant_category == "core"
+            and any(h.category.startswith("pillar:") for h in hits)
+            and all(h.path.endswith(".md") for h in hits if h.category.startswith("pillar:"))
+        )
+        if not pillar_md_only:
+            ch.verified = False
     return ch

--- a/plugins/compass/tests/test_classify.py
+++ b/plugins/compass/tests/test_classify.py
@@ -1,0 +1,58 @@
+"""Tests for classify_commit() verification logic — issue #9 regression suite."""
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).parent.parent))
+
+from lib.classify import classify_commit
+
+_CFG = {
+    "pillars": [
+        {"id": "memory", "paths": ["*.md"], "weight": 1.0, "name": "memory", "description": ""},
+        {"id": "engine", "paths": ["lib/**"], "weight": 1.0, "name": "engine", "description": ""},
+    ],
+    "categories": {
+        "core":    {"paths": [], "weight": 1.0,  "message_patterns": [r"^(feat|fix|refactor|perf)(\(.+\))?!?:"], "body_keywords": []},
+        "tests":   {"paths": ["tests/**"], "weight": 0.5, "message_patterns": [], "body_keywords": []},
+        "docs":    {"paths": ["docs/**", "**/*.md"], "weight": 0.3, "message_patterns": [r"^docs(\(.+\))?:"], "body_keywords": ["pilastro", "manifest", "vision"]},
+        "infra":   {"paths": [".github/**"], "weight": -0.1, "message_patterns": [], "body_keywords": []},
+        "tooling": {"paths": ["scripts/**"], "weight": 0.0, "message_patterns": [], "body_keywords": []},
+    },
+    "ignore": [],
+}
+
+
+def _commit(sha, message, files):
+    return {"sha": sha, "message": message, "ts": 0, "files": files}
+
+
+def test_pillar_md_docs_core_is_verified():
+    # chore(memory) with body keyword "pilastro" touching INDEX.md (pillar:memory, .md)
+    # msg_cat=docs, dominant=core — structural co-occurrence, not a real conflict
+    c = classify_commit(
+        _commit("aaa", "chore(memory): handoff\n\naggiornamento pilastro memoria", ["INDEX.md"]),
+        _CFG,
+    )
+    assert c.dominant_category == "core"
+    assert c.verified is True
+
+
+def test_feat_code_pillar_verified():
+    # feat: touching lib/classify.py (pillar:engine) — msg_cat=core matches dominant=core
+    c = classify_commit(
+        _commit("bbb", "feat: add classifier", ["lib/classify.py"]),
+        _CFG,
+    )
+    assert c.dominant_category == "core"
+    assert c.verified is True
+
+
+def test_docs_non_md_pillar_still_flagged():
+    # docs: touching lib/foo.py (pillar:engine, NOT .md) — msg_cat=docs, dominant=core
+    # pillar file is .py, so pillar_md_only=False → real conflict, still verified=False
+    c = classify_commit(
+        _commit("ccc", "docs: update api reference", ["lib/foo.py"]),
+        _CFG,
+    )
+    assert c.dominant_category == "core"
+    assert c.verified is False


### PR DESCRIPTION
## What

Implements option 1 from issue #9: whitelist the `(msg_cat=docs, dominant_category=core)` co-occurrence in `classify_commit()` when **all** pillar-tagged files in the commit are `.md`.

## Why this is the right fix

`classify_commit()` already intentionally collapses every `pillar:*` file to `"core"` for the `dominant_category` calculation. Any project that maps narrative `.md` files to pillars in `.compass.toml` will structurally produce `dominant_category="core"` for those commits — by design, not by mistake.

At the same time, `_category_from_message()` can return `"docs"` from body keywords (`pilastro`, `manifest`, `vision`) that appear naturally in meta/governance commits. The mismatch is structural, not semantic: the same `.md` file is **both** a doc (form) and a pillar carrier (semantic mapping), so the verification rule shouldn't penalize it.

## Change

`plugins/compass/lib/classify.py` — `classify_commit()`, last block:

```python
# before
if msg_cat is not None and msg_cat != ch.dominant_category:
    ch.verified = False

# after
if msg_cat is not None and msg_cat != ch.dominant_category:
    pillar_md_only = (
        msg_cat == "docs"
        and ch.dominant_category == "core"
        and any(h.category.startswith("pillar:") for h in hits)
        and all(h.path.endswith(".md") for h in hits if h.category.startswith("pillar:"))
    )
    if not pillar_md_only:
        ch.verified = False
```

The guard is deliberately tight: it only fires when **all four** conditions hold, so a `docs:` commit that genuinely touches non-md pillar files (e.g. a `.py` under a pillar path) still gets `verified=False`.

## Tests added

`plugins/compass/tests/test_classify.py` (new file — no test suite existed):

| Case | Expected |
|---|---|
| `chore(memory)` + body keyword `pilastro` touching `INDEX.md` (pillar `.md`) | `verified=True` ← new behaviour |
| `feat:` touching `lib/classify.py` (pillar `.py`) | `verified=True` ← unchanged |
| `docs:` touching `lib/foo.py` (pillar `.py`, not `.md`) | `verified=False` ← still flagged |

Run with: `cd plugins/compass && python -m pytest tests/`

## References

- Closes #9
- Full diagnostic + repro: https://github.com/MasterDD-L34D/evo-swarm/blob/main/docs/COMPASS-DRIFT-FALSE-POSITIVE.md
- Plugin version at report time: 0.4.3

---
_Generated by [Claude Code](https://claude.ai/code/session_01GwaLQKHJ1xTzWwNRhn5Eye)_